### PR TITLE
Minor improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,11 @@
             },
             {
                 "key": "ctrl+p",
+                "command": "emacs.cursorUp",
+                "when": "terminalFocus"
+            },
+            {
+                "key": "ctrl+p",
                 "command": "closeFindWidget",
                 "when": "editorFocus && findWidgetVisible"
             },
@@ -145,6 +150,11 @@
                 "key": "ctrl+e",
                 "command": "emacs.cursorEnd",
                 "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+e",
+                "command": "emacs.cursorEnd",
+                "when": "terminalFocus"
             },
             {
                 "key": "ctrl+e",

--- a/package.json
+++ b/package.json
@@ -637,6 +637,10 @@
                 "key": "ctrl+x ctrl+u",
                 "command": "editor.action.transformToUppercase",
                 "when": "editorTextFocus && !editorReadonly"
+            },
+            {
+                "key": "alt+backspace",
+                "command": "deleteWordLeft"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -337,7 +337,7 @@
             },
             {
                 "key": "ctrl+j",
-                "command": "editor.action.insertLineAfter",
+                "command": "emacs.C-j",
                 "when": "editorTextFocus && !editorReadonly"
             },
             {

--- a/package.json
+++ b/package.json
@@ -336,6 +336,11 @@
                 "when": "editorFocus && findWidgetVisible"
             },
             {
+                "key": "ctrl+m",
+                "command": "emacs.C-j",
+                "when": "editorTextFocus && !editorReadonly"
+            },
+            {
                 "key": "ctrl+j",
                 "command": "emacs.C-j",
                 "when": "editorTextFocus && !editorReadonly"

--- a/package.json
+++ b/package.json
@@ -642,11 +642,11 @@
         "lint": "tslint -p tslint.json --type-check **/*.ts"
     },
     "devDependencies": {
-        "mocha": "^3.1.2",
-        "typescript": "^2.0.7",
-        "vscode": "^1.0.3",
-        "@types/mocha": "^2.2.32",
-        "@types/node": "^6.0.40"
+        "@types/mocha": "^2.2.41",
+        "@types/node": "^6.0.81",
+        "mocha": "^3.4.2",
+        "typescript": "^2.4.1",
+        "vscode": "^1.1.4"
     },
     "dependencies": {
         "clipboardy": "^1.1.4"

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -329,4 +329,10 @@ export class Editor {
 		const range = new vscode.Range(selection.start, selection.end)
 		editor.revealRange(range, vscode.TextEditorRevealType.InCenter)
 	}
+
+	breakLine() {
+		vscode.commands.executeCommand("lineBreakInsert");
+		vscode.commands.executeCommand("emacs.cursorHome");
+		vscode.commands.executeCommand("emacs.cursorDown");
+	}
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -43,7 +43,7 @@ export class Editor {
 	}
 
 	setStatusBarPermanentMessage(text: string): vscode.Disposable {
-		return vscode.window.setStatusBarMessage(text); 
+		return vscode.window.setStatusBarMessage(text);
 	}
 
 	getSelectionRange(): vscode.Range {
@@ -81,7 +81,7 @@ export class Editor {
 			isOnLastLine = Editor.isOnLastLine()
 
 		// Move down an entire line (not just the wrapped part), and to the beginning.
-		await vscode.commands.executeCommand("cursorMove", { to: "down", by: "line", select: false })		
+		await vscode.commands.executeCommand("cursorMove", { to: "down", by: "line", select: false })
 		if (!isOnLastLine) {
 			await vscode.commands.executeCommand("cursorMove", { to: "wrappedLineStart" })
 		}
@@ -168,11 +168,11 @@ export class Editor {
 		}
 		selection = new vscode.Selection(nextLine, nextLine);
 		vscode.window.activeTextEditor.selection = selection;
-		
+
 		for (let line = selection.start.line;
 				line < doc.lineCount - 1  && doc.lineAt(line).range.isEmpty;
 		    	++line) {
-			
+
 			await vscode.commands.executeCommand("deleteRight")
 		}
 		vscode.window.activeTextEditor.selection = new vscode.Selection(anchor, anchor)
@@ -188,7 +188,7 @@ export class Editor {
 
 	setRMode(): void {
 		this.setStatusBarPermanentMessage("C-x r");
-		this.keybindProgressMode = KeybindProgressMode.RMode; 
+		this.keybindProgressMode = KeybindProgressMode.RMode;
 		return;
 	}
 
@@ -283,7 +283,7 @@ export class Editor {
 				text: text
 			});
 		}
-		return;    
+		return;
 	}
 
 	saveTextToRegister(registerName: string): void {
@@ -301,7 +301,7 @@ export class Editor {
 	}
 
 	restoreTextFromRegister(registerName: string): void {
-		vscode.commands.executeCommand("emacs.exitMarkMode"); // emulate Emacs 
+		vscode.commands.executeCommand("emacs.exitMarkMode"); // emulate Emacs
 		let obj : RegisterContent = this.registersStorage[registerName];
 		if (null === obj) {
 			this.setStatusBarMessage("Register does not contain text.");
@@ -314,14 +314,14 @@ export class Editor {
 					editBuilder.insert(this.getSelection().active, content);
 				});
 			}
-		}  
+		}
 		return;
 	}
 
 	deleteLine() : void {
 		vscode.commands.executeCommand("emacs.exitMarkMode"); // emulate Emacs
 		vscode.commands.executeCommand("editor.action.deleteLines");
-	}   
+	}
 
 	scrollLineToCenter() {
 		const editor = vscode.window.activeTextEditor

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
             // Edit
             "C-k", "C-w", "M-w", "C-y", "C-x_C-o",
-            "C-x_u", "C-/", "C-S_bs",
+            "C-x_u", "C-/", "C-j", "C-S_bs",
 
             // Navigation
             "C-l",
@@ -50,7 +50,7 @@ export function activate(context: vscode.ExtensionContext): void {
 		if (!vscode.window.activeTextEditor) {
 			return;
 		}
-		op.onType(args.text);        
+		op.onType(args.text);
     }));
 
     initMarkMode(context);

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -1,4 +1,3 @@
-import * as vscode from 'vscode';
 import {Editor} from './editor';
 
 export class Operation {
@@ -32,9 +31,7 @@ export class Operation {
                 this.editor.setStatusBarMessage("Undo!");
             },
             'C-j': () => {
-                vscode.commands.executeCommand("lineBreakInsert");
-                vscode.commands.executeCommand("emacs.cursorHome");
-                vscode.commands.executeCommand("emacs.cursorDown");
+                this.editor.breakLine();
             },
             'C-g': () => {
                 this.editor.setStatusBarMessage("Quit");

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import {Editor} from './editor';
 
 export class Operation {
@@ -29,6 +30,11 @@ export class Operation {
             "C-/": () => {
                 this.editor.undo();
                 this.editor.setStatusBarMessage("Undo!");
+            },
+            'C-j': () => {
+                vscode.commands.executeCommand("lineBreakInsert");
+                vscode.commands.executeCommand("emacs.cursorHome");
+                vscode.commands.executeCommand("emacs.cursorDown");
             },
             'C-g': () => {
                 this.editor.setStatusBarMessage("Quit");


### PR DESCRIPTION
* Update devDependencies section in package.json file
* Remove trailing spaces and tabs in editor.ts file
* Change C-j to behave as similar as possible as ENTER
* Add C-m as a C-j alias (in early emacs versions C-m breaks the line, not C-j)
* Add missing M-backspace shortcut to delete left word
* Move hack C-j code to editor.ts file
* Fix C-p and C-e shortcuts to work on the integrated terminal, instead of opening the command palette