### PR TITLE
Moderate improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1886 @@
+{
+    "name": "vscode-emacs-friendly",
+    "version": "0.6.1",
+    "lockfileVersion": 1,
+    "dependencies": {
+        "@types/mocha": {
+            "version": "2.2.41",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.41.tgz",
+            "integrity": "sha1-4nzwgXFT658nE7LT9saPHhw8pgg=",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "6.0.81",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.81.tgz",
+            "integrity": "sha512-KdtXOH8l9O2wwOOX+swjbFx+YW/RJFfI14o6S50+Zy79FK1WFGkzFdDsiuNjrG5L6FaBSKpKzSpWgTvXurbbYg==",
+            "dev": true
+        },
+        "ajv": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+            "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "arr-diff": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "dev": true
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
+        },
+        "array-differ": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+            "dev": true
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "array-unique": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "dev": true
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "asn1": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+            "dev": true
+        },
+        "assert-plus": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "aws-sign2": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "dev": true,
+            "optional": true
+        },
+        "beeper": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+            "dev": true
+        },
+        "block-stream": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+            "dev": true
+        },
+        "boom": {
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "dev": true
+        },
+        "braces": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "dev": true
+        },
+        "browser-stdout": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+            "dev": true
+        },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true
+        },
+        "caseless": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+            "dev": true
+        },
+        "chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
+            "dependencies": {
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "clipboardy": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.1.4.tgz",
+            "integrity": "sha1-UbF1dPxoJYji3Slc+m5qoQnqte4="
+        },
+        "clone": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+            "dev": true
+        },
+        "clone-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+            "dev": true
+        },
+        "clone-stats": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+            "dev": true
+        },
+        "cloneable-readable": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+            "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+            "dev": true
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+            "dev": true
+        },
+        "commander": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+            "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "cross-spawn": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk="
+        },
+        "cryptiles": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+            "dev": true
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "dateformat": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+            "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
+            "dev": true
+        },
+        "debug": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+            "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+            "dev": true
+        },
+        "deep-assign": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+            "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
+            "dev": true
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "diff": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+            "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+            "dev": true
+        },
+        "duplexer": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+            "dev": true
+        },
+        "duplexer2": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+            "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+            "dev": true,
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.1.14",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "duplexify": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+            "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
+            "dev": true
+        },
+        "ecc-jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "dev": true,
+            "optional": true
+        },
+        "end-of-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+            "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
+            "dev": true,
+            "dependencies": {
+                "once": {
+                    "version": "1.3.3",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                    "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                    "dev": true
+                }
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "event-stream": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+            "dev": true
+        },
+        "execa": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
+            "integrity": "sha1-V7aaWU8IF1nGnlNw8NF7nLEWWP4="
+        },
+        "expand-brackets": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "dev": true
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "dev": true
+        },
+        "extend": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "dev": true
+        },
+        "extend-shallow": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+            "dev": true
+        },
+        "extglob": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "dev": true,
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+            "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+            "dev": true
+        },
+        "fancy-log": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+            "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+            "dev": true
+        },
+        "fd-slicer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "dev": true
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "dev": true
+        },
+        "fill-range": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+            "dev": true
+        },
+        "first-chunk-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+            "dev": true
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "dev": true
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+            "dev": true
+        },
+        "from": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fstream": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "dev": true
+        },
+        "generate-function": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+            "dev": true
+        },
+        "generate-object-property": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+            "dev": true
+        },
+        "get-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "glob": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+            "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+            "dev": true
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "dev": true,
+            "dependencies": {
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "dev": true
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true
+                }
+            }
+        },
+        "glob-parent": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+            "dev": true
+        },
+        "glob-stream": {
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+            "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+            "dev": true,
+            "dependencies": {
+                "glob": {
+                    "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "0.6.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                    "dev": true
+                }
+            }
+        },
+        "glogg": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+            "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+            "dev": true
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
+        },
+        "graceful-readlink": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+            "dev": true
+        },
+        "growl": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+            "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+            "dev": true
+        },
+        "gulp-chmod": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
+            "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
+            "dev": true
+        },
+        "gulp-filter": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.0.0.tgz",
+            "integrity": "sha1-z6gZZvtniE8rp1SwZxUpKUKNWbw=",
+            "dev": true
+        },
+        "gulp-gunzip": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-0.0.3.tgz",
+            "integrity": "sha1-e24HsPWP09QlFcSOrVpj3wVy9i8=",
+            "dev": true,
+            "dependencies": {
+                "clone": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "0.6.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "0.4.6",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "dev": true
+                }
+            }
+        },
+        "gulp-remote-src": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.2.tgz",
+            "integrity": "sha1-zrN3DjREMo1hOG+6qrIAvBHNmKg=",
+            "dev": true,
+            "dependencies": {
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+                    "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+                    "dev": true
+                },
+                "request": {
+                    "version": "2.79.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+                    "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
+                    "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+                    "dev": true
+                }
+            }
+        },
+        "gulp-sourcemaps": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+            "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+            "dev": true,
+            "dependencies": {
+                "vinyl": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                    "dev": true
+                }
+            }
+        },
+        "gulp-symdest": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
+            "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
+            "dev": true
+        },
+        "gulp-untar": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
+            "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
+            "dev": true
+        },
+        "gulp-util": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+            "dev": true,
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "gulp-vinyl-zip": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-1.4.0.tgz",
+            "integrity": "sha1-VjgvLMtXIxuwR4x4c3zNVylzvuE=",
+            "dev": true,
+            "dependencies": {
+                "clone": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "0.6.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "0.4.6",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "dev": true
+                }
+            }
+        },
+        "gulplog": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+            "dev": true
+        },
+        "har-schema": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+            "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+            "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+            "dev": true
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true
+        },
+        "has-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+            "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+            "dev": true
+        },
+        "has-gulplog": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+            "dev": true
+        },
+        "hawk": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+            "dev": true
+        },
+        "hoek": {
+            "version": "2.16.3",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+            "dev": true
+        },
+        "http-signature": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "is": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+            "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+            "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+            "dev": true
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "dev": true
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "dev": true
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+            "dev": true
+        },
+        "is-my-json-valid": {
+            "version": "2.16.0",
+            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+            "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+            "dev": true
+        },
+        "is-number": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "dev": true
+        },
+        "is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "dev": true
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "dev": true
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "dev": true
+        },
+        "is-property": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+            "dev": true
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
+        "is-valid-glob": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+            "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
+        "isobject": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "dev": true
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true,
+            "optional": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "json3": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+            "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+            "dev": true
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonpointer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+            "dev": true
+        },
+        "jsprim": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+            "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+            "dev": true,
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dev": true
+        },
+        "lodash._baseassign": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+            "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+            "dev": true
+        },
+        "lodash._basecopy": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+            "dev": true
+        },
+        "lodash._basecreate": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+            "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+            "dev": true
+        },
+        "lodash._basetostring": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+            "dev": true
+        },
+        "lodash._basevalues": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+            "dev": true
+        },
+        "lodash._getnative": {
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+            "dev": true
+        },
+        "lodash._isiterateecall": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+            "dev": true
+        },
+        "lodash._reescape": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+            "dev": true
+        },
+        "lodash._reevaluate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+            "dev": true
+        },
+        "lodash._reinterpolate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+            "dev": true
+        },
+        "lodash._root": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+            "dev": true
+        },
+        "lodash.create": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+            "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+            "dev": true
+        },
+        "lodash.escape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+            "dev": true
+        },
+        "lodash.isarguments": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+            "dev": true
+        },
+        "lodash.isarray": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+            "dev": true
+        },
+        "lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+            "dev": true
+        },
+        "lodash.keys": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+            "dev": true
+        },
+        "lodash.restparam": {
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+            "dev": true
+        },
+        "lodash.template": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+            "dev": true
+        },
+        "lodash.templatesettings": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+            "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew=="
+        },
+        "map-stream": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+            "dev": true
+        },
+        "merge-stream": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+            "dev": true
+        },
+        "micromatch": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "dev": true,
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true
+                }
+            }
+        },
+        "mime-db": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+            "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.15",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+            "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true
+        },
+        "mocha": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
+            "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+            "dev": true
+        },
+        "ms": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+            "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+            "dev": true
+        },
+        "multimatch": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+            "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+            "dev": true
+        },
+        "multipipe": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+            "dev": true
+        },
+        "node.extend": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+            "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+            "dev": true
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8="
+        },
+        "oauth-sign": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+            "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+            "dev": true
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true
+        },
+        "ordered-read-streams": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+            "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+            "dev": true
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "dev": true,
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true
+                }
+            }
+        },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+        },
+        "pause-stream": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+            "dev": true
+        },
+        "pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+            "dev": true
+        },
+        "performance-now": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+            "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+            "dev": true
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.3.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+            "dev": true
+        },
+        "querystringify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+            "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
+            "dev": true
+        },
+        "queue": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+            "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
+            "dev": true
+        },
+        "randomatic": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+            "dev": true,
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true
+                }
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+            "dev": true
+        },
+        "regex-cache": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+            "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+            "dev": true
+        },
+        "remove-trailing-separator": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+            "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+            "dev": true
+        },
+        "repeat-element": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "replace-ext": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+            "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+            "dev": true
+        },
+        "request": {
+            "version": "2.81.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+            "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+            "dev": true,
+            "dependencies": {
+                "caseless": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+                    "dev": true
+                },
+                "har-validator": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                    "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.4.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                    "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+                    "dev": true
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+                    "dev": true
+                }
+            }
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+            "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+            "dev": true
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+            "dev": true
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo="
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+        },
+        "sntp": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.4.15",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+            "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+            "dev": true
+        },
+        "sparkles": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+            "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+            "dev": true
+        },
+        "split": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "dev": true,
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "stat-mode": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+            "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
+            "dev": true
+        },
+        "stream-combiner": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+            "dev": true
+        },
+        "stream-shift": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+            "dev": true
+        },
+        "streamfilter": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz",
+            "integrity": "sha1-h1BxEb644phFFxe1Ec/tjwAqv1M=",
+            "dev": true
+        },
+        "streamifier": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+            "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "dev": true
+        },
+        "stringstream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true
+        },
+        "strip-bom": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true
+        },
+        "strip-bom-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+            "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+            "dev": true
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+        },
+        "supports-color": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+            "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+            "dev": true
+        },
+        "tar": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "through2": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "dev": true
+        },
+        "through2-filter": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+            "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+            "dev": true
+        },
+        "time-stamp": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+            "dev": true
+        },
+        "to-absolute-glob": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+            "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+            "dev": true
+        },
+        "tough-cookie": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+            "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+            "dev": true
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true,
+            "optional": true
+        },
+        "typescript": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
+            "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
+            "dev": true
+        },
+        "unique-stream": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+            "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+            "dev": true
+        },
+        "url-parse": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+            "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+            "dev": true
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+            "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+            "dev": true
+        },
+        "vali-date": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+            "dev": true
+        },
+        "verror": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+            "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+            "dev": true
+        },
+        "vinyl": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+            "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+            "dev": true
+        },
+        "vinyl-fs": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+            "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+            "dev": true,
+            "dependencies": {
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                    "dev": true
+                }
+            }
+        },
+        "vinyl-source-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
+            "integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
+            "dev": true,
+            "dependencies": {
+                "clone": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "0.6.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "0.4.6",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+                    "dev": true
+                }
+            }
+        },
+        "vscode": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.4.tgz",
+            "integrity": "sha1-Hx1NZi1VyaKLxGeqy2MikfcKaG0=",
+            "dev": true
+        },
+        "which": {
+            "version": "1.2.14",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+            "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        },
+        "yauzl": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
+            "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
+            "dev": true
+        },
+        "yazl": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.2.tgz",
+            "integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg=",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -306,6 +306,11 @@
                 "when": "editorFocus && findWidgetVisible"
             },
             {
+                "key": "alt+0 ctrl+k",
+                "command": "emacs.M-0_C-k",
+                "when": "editorTextFocus && !editorReadonly"
+            },
+            {
                 "key": "ctrl+k",
                 "command": "emacs.C-k",
                 "when": "editorTextFocus && !editorReadonly"

--- a/package.json
+++ b/package.json
@@ -666,6 +666,11 @@
                 "key": "ctrl+u ctrl+space",
                 "command": "emacs.C-u_C-spc",
                 "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+x ctrl+x",
+                "command": "emacs.C-x_C-x",
+                "when": "editorTextFocus"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
             },
             {
                 "key": "ctrl+f",
+                "command": "emacs.cursorRight",
+                "when": "terminalFocus"
+            },
+            {
+                "key": "ctrl+f",
                 "command": "closeFindWidget",
                 "when": "editorFocus && findWidgetVisible"
             },

--- a/package.json
+++ b/package.json
@@ -530,6 +530,11 @@
             },
             {
                 "key": "ctrl+x ctrl+s",
+                "command": "workbench.action.files.saveAll",
+                "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+x s",
                 "command": "workbench.action.files.save",
                 "when": "editorTextFocus"
             },

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -16,6 +16,24 @@ export class Editor {
 	private registersStorage: { [key:string] : RegisterContent; };
 	private lastKill: vscode.Position // if kill position stays the same, append to clipboard
 	private justDidKill: boolean
+	private static inMarkMode : boolean
+	private static markHasMoved : boolean
+
+	static getInMarkMode() : boolean {
+		return Editor.inMarkMode;
+	}
+
+	static setInMarkMode(val:boolean) : void {
+		Editor.inMarkMode = val;
+	}
+
+	static getMarkHasMoved() : boolean {
+		return Editor.markHasMoved;
+	}
+
+	static setMarkHasMoved(val:boolean) : void {
+		Editor.markHasMoved = val;
+	}
 
 	constructor() {
 		this.keybindProgressMode = KeybindProgressMode.None
@@ -334,5 +352,20 @@ export class Editor {
 		vscode.commands.executeCommand("lineBreakInsert");
 		vscode.commands.executeCommand("emacs.cursorHome");
 		vscode.commands.executeCommand("emacs.cursorDown");
+	}
+
+	enterMarkMode() :void {
+		if (Editor.inMarkMode && !Editor.markHasMoved) {
+			this.exitMarkMode();
+		} else {
+			this.exitMarkMode();
+			Editor.inMarkMode = true;
+			Editor.markHasMoved = false;
+		}
+	}
+
+	exitMarkMode() : void {
+		vscode.commands.executeCommand("cancelSelection");
+		Editor.inMarkMode = false;
 	}
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -64,15 +64,18 @@ export class Editor {
 			if (jumpPosition.line - currentPosition.line != 0) {
 				vscode.commands.executeCommand("cursorMove", {
 					to:"down",
-					value:jumpPosition.line - currentPosition.line
+					value:jumpPosition.line - currentPosition.line,
 				})
 			}
-			if (jumpPosition.character - currentPosition.character != 0) {
-				vscode.commands.executeCommand("cursorMove", {
-					to:"right",
-					value:jumpPosition.character - currentPosition.character
-				})
-			}
+
+			vscode.commands.executeCommand("cursorMove", {
+				to:"wrappedLineStart",
+			})
+
+			vscode.commands.executeCommand("cursorMove", {
+				to:"right",
+				value:jumpPosition.character,
+			})
 		}
 	}
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,384 +1,382 @@
 import * as vscode from 'vscode';
-import {RegisterContent, RectangleContent, RegisterKind} from './registers';
+import { RegisterContent, RectangleContent, RegisterKind } from './registers';
 
 enum KeybindProgressMode {
-	None,   // No current keybind is currently in progress
-	RMode,  // Rectangle and/or Register keybinding  [started by 'C-x+r'] is currently in progress
-	RModeS, // 'Save Region in register' keybinding [started by 'C-x+r+s'] is currently in progress
-	RModeI, // 'Insert Register content into buffer' keybinding [started by 'C-x+r+i'] is currently in progress
-	AMode,  // (FUTURE, TBD) Abbrev keybinding  [started by 'C-x+a'] is currently in progress
-	MacroRecordingMode  // (FUTURE, TBD) Emacs macro recording [started by 'Ctrl-x+('] is currently in progress
+    None,   // No current keybind is currently in progress
+    RMode,  // Rectangle and/or Register keybinding  [started by 'C-x+r'] is currently in progress
+    RModeS, // 'Save Region in register' keybinding [started by 'C-x+r+s'] is currently in progress
+    RModeI, // 'Insert Register content into buffer' keybinding [started by 'C-x+r+i'] is currently in progress
+    AMode,  // (FUTURE, TBD) Abbrev keybinding  [started by 'C-x+a'] is currently in progress
+    MacroRecordingMode  // (FUTURE, TBD) Emacs macro recording [started by 'Ctrl-x+('] is currently in progress
 };
 
 export class Editor {
-	private keybindProgressMode: KeybindProgressMode;
-	private registersStorage: { [key:string] : RegisterContent; };
-	private lastKill: vscode.Position // if kill position stays the same, append to clipboard
-	private justDidKill: boolean
-	private static inMarkMode : boolean = false
-	private static markHasMoved : boolean = false
-	private positions: Array<vscode.Position> = new Array();
+    private keybindProgressMode: KeybindProgressMode;
+    private registersStorage: { [key: string]: RegisterContent; };
+    private lastKill: vscode.Position // if kill position stays the same, append to clipboard
+    private justDidKill: boolean
+    private static inMarkMode: boolean = false
+    private static markHasMoved: boolean = false
+    private positions: Array<vscode.Position> = new Array();
 
-	static getInMarkMode() : boolean {
-		return Editor.inMarkMode;
-	}
+    static getInMarkMode(): boolean {
+        return Editor.inMarkMode;
+    }
 
-	static setInMarkMode(val:boolean) : void {
-		Editor.inMarkMode = val;
-	}
+    static setInMarkMode(val: boolean): void {
+        Editor.inMarkMode = val;
+    }
 
-	static getMarkHasMoved() : boolean {
-		return Editor.markHasMoved;
-	}
+    static getMarkHasMoved(): boolean {
+        return Editor.markHasMoved;
+    }
 
-	static setMarkHasMoved(val:boolean) : void {
-		Editor.markHasMoved = val;
-	}
+    static setMarkHasMoved(val: boolean): void {
+        Editor.markHasMoved = val;
+    }
 
-	constructor() {
-		this.keybindProgressMode = KeybindProgressMode.None
-		this.registersStorage = {}
-		this.justDidKill = false
-		this.lastKill = null
+    constructor() {
+        this.keybindProgressMode = KeybindProgressMode.None
+        this.registersStorage = {}
+        this.justDidKill = false
+        this.lastKill = null
 
-		vscode.window.onDidChangeActiveTextEditor(event => {
-			this.lastKill = null
-		})
-		vscode.workspace.onDidChangeTextDocument(event => {
-			if (!this.justDidKill) {
-				this.lastKill = null
-			}
-			this.justDidKill = false
-		})
-	}
+        vscode.window.onDidChangeActiveTextEditor(event => {
+            this.lastKill = null
+        })
+        vscode.workspace.onDidChangeTextDocument(event => {
+            if (!this.justDidKill) {
+                this.lastKill = null
+            }
+            this.justDidKill = false
+        })
+    }
 
-	static isOnLastLine(): boolean {
-		return vscode.window.activeTextEditor.selection.active.line == vscode.window.activeTextEditor.document.lineCount - 1
-	}
+    static isOnLastLine(): boolean {
+        return vscode.window.activeTextEditor.selection.active.line == vscode.window.activeTextEditor.document.lineCount - 1
+    }
 
-	goBack(select : boolean) : void {
-		if (this.positions.length > 0) {
-			var jumpPosition = this.positions.pop()
-			var currentPosition = vscode.window.activeTextEditor.selection.active;
+    goBack(select: boolean): void {
+        if (this.positions.length > 0) {
+            var jumpPosition = this.positions.pop()
+            var currentPosition = vscode.window.activeTextEditor.selection.active;
 
-			if (jumpPosition.line - currentPosition.line != 0) {
-				vscode.commands.executeCommand("cursorMove", {
-					to:"down",
-					value:jumpPosition.line - currentPosition.line,
-					select:select
-				})
-			}
+            if (jumpPosition.line - currentPosition.line != 0) {
+                vscode.commands.executeCommand("cursorMove", {
+                    to: "down",
+                    value: jumpPosition.line - currentPosition.line,
+                    select: select
+                })
+            }
 
-			vscode.commands.executeCommand("cursorMove", {
-				to:"wrappedLineStart",
-				select:select
-			})
+            vscode.commands.executeCommand("cursorMove", {
+                to: "wrappedLineStart",
+                select: select
+            })
 
-			vscode.commands.executeCommand("cursorMove", {
-				to:"right",
-				value:jumpPosition.character,
-				select:select
-			})
-		}
-	}
+            vscode.commands.executeCommand("cursorMove", {
+                to: "right",
+                value: jumpPosition.character,
+                select: select
+            })
+        }
+    }
 
-	setStatusBarMessage(text: string): vscode.Disposable {
-		return vscode.window.setStatusBarMessage(text, 1000);
-	}
+    setStatusBarMessage(text: string): vscode.Disposable {
+        return vscode.window.setStatusBarMessage(text, 1000);
+    }
 
-	setStatusBarPermanentMessage(text: string): vscode.Disposable {
-		return vscode.window.setStatusBarMessage(text);
-	}
+    setStatusBarPermanentMessage(text: string): vscode.Disposable {
+        return vscode.window.setStatusBarMessage(text);
+    }
 
-	getSelectionRange(): vscode.Range {
-		let selection = vscode.window.activeTextEditor.selection,
-			start = selection.start,
-			end = selection.end;
+    getSelectionRange(): vscode.Range {
+        let selection = vscode.window.activeTextEditor.selection,
+            start = selection.start,
+            end = selection.end;
 
-		return (start.character !== end.character || start.line !== end.line) ? new vscode.Range(start, end) : null;
-	}
+        return (start.character !== end.character || start.line !== end.line) ? new vscode.Range(start, end) : null;
+    }
 
-	getSelection(): vscode.Selection {
-		return vscode.window.activeTextEditor.selection;
-	}
+    getSelection(): vscode.Selection {
+        return vscode.window.activeTextEditor.selection;
+    }
 
-	getSelectionText(): string {
-		let r = this.getSelectionRange()
-		return r ? vscode.window.activeTextEditor.document.getText(r) : ''
-	}
+    getSelectionText(): string {
+        let r = this.getSelectionRange()
+        return r ? vscode.window.activeTextEditor.document.getText(r) : ''
+    }
 
-	setSelection(start: vscode.Position, end: vscode.Position): void {
-		let editor = vscode.window.activeTextEditor;
-		editor.selection = new vscode.Selection(start, end);
-	}
+    setSelection(start: vscode.Position, end: vscode.Position): void {
+        let editor = vscode.window.activeTextEditor;
+        editor.selection = new vscode.Selection(start, end);
+    }
 
-	getCurrentPos(): vscode.Position {
-		return vscode.window.activeTextEditor.selection.active
-	}
+    getCurrentPos(): vscode.Position {
+        return vscode.window.activeTextEditor.selection.active
+    }
 
-	// Kill to end of line
-	killForward(): void {
-		// Ignore whatever we have selected before
-		vscode.commands.executeCommand("emacs.exitMarkMode")
-		// move cursor to the end of the line and select the text
-		vscode.commands.executeCommand("cursorMove", {
-			to:"wrappedLineEnd",
-			select:true
-		})
-		// editor.action.clipboardCutAction is too slow!
-		vscode.commands.executeCommand("editor.action.clipboardCopyAction");
-		vscode.commands.executeCommand("deleteAllRight");
-	}
+    // Kill to end of line
+    killForward(): void {
+        // Ignore whatever we have selected before
+        vscode.commands.executeCommand("emacs.exitMarkMode")
+        // move cursor to the end of the line and select the text
+        vscode.commands.executeCommand("cursorMove", {
+            to: "wrappedLineEnd",
+            select: true
+        })
+        // editor.action.clipboardCutAction is too slow!
+        vscode.commands.executeCommand("editor.action.clipboardCopyAction");
+        vscode.commands.executeCommand("deleteAllRight");
+    }
 
-	// Kill to beginning of line
-	killBackward(): void {
-		// Ignore whatever we have selected before
-		vscode.commands.executeCommand("emacs.exitMarkMode")
-		// move cursor to the beginning of the line and select the text
-		vscode.commands.executeCommand("cursorMove", {
-			to:"wrappedLineStart",
-			select:true
-		})
-		// editor.action.clipboardCutAction is too slow!
-		vscode.commands.executeCommand("editor.action.clipboardCopyAction");
-		vscode.commands.executeCommand("deleteAllLeft");
-	}
+    // Kill to beginning of line
+    killBackward(): void {
+        // Ignore whatever we have selected before
+        vscode.commands.executeCommand("emacs.exitMarkMode")
+        // move cursor to the beginning of the line and select the text
+        vscode.commands.executeCommand("cursorMove", {
+            to: "wrappedLineStart",
+            select: true
+        })
+        // editor.action.clipboardCutAction is too slow!
+        vscode.commands.executeCommand("editor.action.clipboardCopyAction");
+        vscode.commands.executeCommand("deleteAllLeft");
+    }
 
-	copy(): void {
-		vscode.commands.executeCommand("editor.action.clipboardCopyAction")
-		vscode.commands.executeCommand("emacs.exitMarkMode")
-	}
+    copy(): void {
+        vscode.commands.executeCommand("editor.action.clipboardCopyAction")
+        vscode.commands.executeCommand("emacs.exitMarkMode")
+    }
 
-	cut(): void {
-		vscode.commands.executeCommand("editor.action.clipboardCutAction")
-		Editor.inMarkMode = false
-	}
+    cut(): void {
+        vscode.commands.executeCommand("editor.action.clipboardCutAction")
+        Editor.inMarkMode = false
+    }
 
-	yank(): Thenable<{}> {
-		this.justDidKill = false
-		return Promise.all([
-			vscode.commands.executeCommand("editor.action.clipboardPasteAction"),
-			vscode.commands.executeCommand("emacs.exitMarkMode")])
-	}
+    yank(): Thenable<{}> {
+        this.justDidKill = false
+        return Promise.all([
+            vscode.commands.executeCommand("editor.action.clipboardPasteAction"),
+            vscode.commands.executeCommand("emacs.exitMarkMode")])
+    }
 
-	undo(): void {
-		vscode.commands.executeCommand("undo");
-	}
+    undo(): void {
+        vscode.commands.executeCommand("undo");
+    }
 
-	private getFirstBlankLine(range: vscode.Range): vscode.Range {
-		let doc = vscode.window.activeTextEditor.document;
+    private getFirstBlankLine(range: vscode.Range): vscode.Range {
+        let doc = vscode.window.activeTextEditor.document;
 
-		if (range.start.line === 0) {
-			return range;
-		}
-		range = doc.lineAt(range.start.line - 1).range;
-		while (range.start.line > 0 && range.isEmpty) {
-			range = doc.lineAt(range.start.line - 1).range;
-		}
-		if (range.isEmpty) {
-			return range;
-		} else {
-			return doc.lineAt(range.start.line + 1).range;
-		}
-	}
+        if (range.start.line === 0) {
+            return range;
+        }
+        range = doc.lineAt(range.start.line - 1).range;
+        while (range.start.line > 0 && range.isEmpty) {
+            range = doc.lineAt(range.start.line - 1).range;
+        }
+        if (range.isEmpty) {
+            return range;
+        } else {
+            return doc.lineAt(range.start.line + 1).range;
+        }
+    }
 
-	async deleteBlankLines() {
-		let selection = this.getSelection(),
-			anchor = selection.anchor,
-			doc = vscode.window.activeTextEditor.document,
-			range = doc.lineAt(selection.start.line).range,
-			nextLine: vscode.Position;
+    async deleteBlankLines() {
+        let selection = this.getSelection(),
+            anchor = selection.anchor,
+            doc = vscode.window.activeTextEditor.document,
+            range = doc.lineAt(selection.start.line).range,
+            nextLine: vscode.Position;
 
-		if (range.isEmpty) {
-			range = this.getFirstBlankLine(range);
-			anchor = range.start;
-			nextLine = range.start;
-		} else {
-			nextLine = range.start.translate(1, 0);
-		}
-		selection = new vscode.Selection(nextLine, nextLine);
-		vscode.window.activeTextEditor.selection = selection;
+        if (range.isEmpty) {
+            range = this.getFirstBlankLine(range);
+            anchor = range.start;
+            nextLine = range.start;
+        } else {
+            nextLine = range.start.translate(1, 0);
+        }
+        selection = new vscode.Selection(nextLine, nextLine);
+        vscode.window.activeTextEditor.selection = selection;
 
-		for (let line = selection.start.line;
-				line < doc.lineCount - 1  && doc.lineAt(line).range.isEmpty;
-		    	++line) {
+        for (let line = selection.start.line;
+            line < doc.lineCount - 1 && doc.lineAt(line).range.isEmpty;
+            ++line) {
 
-			await vscode.commands.executeCommand("deleteRight")
-		}
-		vscode.window.activeTextEditor.selection = new vscode.Selection(anchor, anchor)
-	}
+            await vscode.commands.executeCommand("deleteRight")
+        }
+        vscode.window.activeTextEditor.selection = new vscode.Selection(anchor, anchor)
+    }
 
-	static delete(range: vscode.Range = null): Thenable<boolean> {
-		if (range) {
-			return vscode.window.activeTextEditor.edit(editBuilder => {
-				editBuilder.delete(range);
-			});
-		}
-	}
+    static delete(range: vscode.Range = null): Thenable<boolean> {
+        if (range) {
+            return vscode.window.activeTextEditor.edit(editBuilder => {
+                editBuilder.delete(range);
+            });
+        }
+    }
 
-	setRMode(): void {
-		this.setStatusBarPermanentMessage("C-x r");
-		this.keybindProgressMode = KeybindProgressMode.RMode;
-		return;
-	}
+    setRMode(): void {
+        this.setStatusBarPermanentMessage("C-x r");
+        this.keybindProgressMode = KeybindProgressMode.RMode;
+        return;
+    }
 
-	onType(text: string): void {
-		let fHandled = false;
-		switch(this.keybindProgressMode)
-		{
-			case KeybindProgressMode.RMode:
-				switch (text)
-				{
-					// Rectangles
-					case 'r':
-						this.setStatusBarMessage("'C-x r r' (Copy rectangle to register) is not supported.");
-						this.keybindProgressMode = KeybindProgressMode.None;
-						fHandled = true;
-						break;
+    onType(text: string): void {
+        let fHandled = false;
+        switch (this.keybindProgressMode) {
+            case KeybindProgressMode.RMode:
+                switch (text) {
+                    // Rectangles
+                    case 'r':
+                        this.setStatusBarMessage("'C-x r r' (Copy rectangle to register) is not supported.");
+                        this.keybindProgressMode = KeybindProgressMode.None;
+                        fHandled = true;
+                        break;
 
-					case 'k':
-						this.setStatusBarMessage("'C-x r k' (Kill rectangle) is not supported.");
-						this.keybindProgressMode = KeybindProgressMode.None;
-						fHandled = true;
-						break;
+                    case 'k':
+                        this.setStatusBarMessage("'C-x r k' (Kill rectangle) is not supported.");
+                        this.keybindProgressMode = KeybindProgressMode.None;
+                        fHandled = true;
+                        break;
 
-					case 'y':
-						this.setStatusBarMessage("'C-x r y' (Yank rectangle) is not supported.");
-						this.keybindProgressMode = KeybindProgressMode.None;
-						fHandled = true;
-						break;
+                    case 'y':
+                        this.setStatusBarMessage("'C-x r y' (Yank rectangle) is not supported.");
+                        this.keybindProgressMode = KeybindProgressMode.None;
+                        fHandled = true;
+                        break;
 
-					case 'o':
-						this.setStatusBarMessage("'C-x r o' (Open rectangle) is not supported.");
-						this.keybindProgressMode = KeybindProgressMode.None;
-						fHandled = true;
-						break;
+                    case 'o':
+                        this.setStatusBarMessage("'C-x r o' (Open rectangle) is not supported.");
+                        this.keybindProgressMode = KeybindProgressMode.None;
+                        fHandled = true;
+                        break;
 
-					case 'c':
-						this.setStatusBarMessage("'C-x r c' (Blank out rectangle) is not supported.");
-						this.keybindProgressMode = KeybindProgressMode.None;
-						fHandled = true;
-						break;
+                    case 'c':
+                        this.setStatusBarMessage("'C-x r c' (Blank out rectangle) is not supported.");
+                        this.keybindProgressMode = KeybindProgressMode.None;
+                        fHandled = true;
+                        break;
 
-					case 't':
-						this.setStatusBarMessage("'C-x r t' (prefix each line with a string) is not supported.");
-						this.keybindProgressMode = KeybindProgressMode.None;
-						fHandled = true;
-						break;
+                    case 't':
+                        this.setStatusBarMessage("'C-x r t' (prefix each line with a string) is not supported.");
+                        this.keybindProgressMode = KeybindProgressMode.None;
+                        fHandled = true;
+                        break;
 
-					// Registers
-					case 's':
-						this.setStatusBarPermanentMessage("Copy to register:");
-						this.keybindProgressMode = KeybindProgressMode.RModeS;
-						fHandled = true;
-						break;
+                    // Registers
+                    case 's':
+                        this.setStatusBarPermanentMessage("Copy to register:");
+                        this.keybindProgressMode = KeybindProgressMode.RModeS;
+                        fHandled = true;
+                        break;
 
-					case 'i':
-						this.setStatusBarPermanentMessage("Insert register:");
-						this.keybindProgressMode = KeybindProgressMode.RModeI;
-						fHandled = true;
-						break;
+                    case 'i':
+                        this.setStatusBarPermanentMessage("Insert register:");
+                        this.keybindProgressMode = KeybindProgressMode.RModeI;
+                        fHandled = true;
+                        break;
 
-					default:
-						break;
-				}
-				break;
+                    default:
+                        break;
+                }
+                break;
 
-			case KeybindProgressMode.RModeS:
-				this.setStatusBarPermanentMessage("");
-				this.saveTextToRegister(text);
-				this.keybindProgressMode = KeybindProgressMode.None;
-				fHandled = true;
-				break;
+            case KeybindProgressMode.RModeS:
+                this.setStatusBarPermanentMessage("");
+                this.saveTextToRegister(text);
+                this.keybindProgressMode = KeybindProgressMode.None;
+                fHandled = true;
+                break;
 
-			case KeybindProgressMode.RModeI:
-				this.setStatusBarPermanentMessage("");
-				this.restoreTextFromRegister(text);
-				this.keybindProgressMode = KeybindProgressMode.None;
-				fHandled = true;
-				break;
+            case KeybindProgressMode.RModeI:
+                this.setStatusBarPermanentMessage("");
+                this.restoreTextFromRegister(text);
+                this.keybindProgressMode = KeybindProgressMode.None;
+                fHandled = true;
+                break;
 
-			case KeybindProgressMode.AMode: // not supported [yet]
-			case KeybindProgressMode.MacroRecordingMode: // not supported [yet]
-			case KeybindProgressMode.None:
-			default:
-				this.keybindProgressMode = KeybindProgressMode.None;
-				this.setStatusBarPermanentMessage("");
-				break;
-		}
+            case KeybindProgressMode.AMode: // not supported [yet]
+            case KeybindProgressMode.MacroRecordingMode: // not supported [yet]
+            case KeybindProgressMode.None:
+            default:
+                this.keybindProgressMode = KeybindProgressMode.None;
+                this.setStatusBarPermanentMessage("");
+                break;
+        }
 
-		if (!fHandled) {
-			// default input handling: pass control to VSCode
-			vscode.commands.executeCommand('default:type', {
-				text: text
-			});
-		}
-		return;
-	}
+        if (!fHandled) {
+            // default input handling: pass control to VSCode
+            vscode.commands.executeCommand('default:type', {
+                text: text
+            });
+        }
+        return;
+    }
 
-	saveTextToRegister(registerName: string): void {
-		if (null === registerName) {
-			return;
-		}
-		let range : vscode.Range = this.getSelectionRange();
-		if (range !== null) {
-			let selectedText = vscode.window.activeTextEditor.document.getText(range);
-			if (null !== selectedText) {
-				this.registersStorage[registerName] = RegisterContent.fromRegion(selectedText);
-			}
-		}
-		return;
-	}
+    saveTextToRegister(registerName: string): void {
+        if (null === registerName) {
+            return;
+        }
+        let range: vscode.Range = this.getSelectionRange();
+        if (range !== null) {
+            let selectedText = vscode.window.activeTextEditor.document.getText(range);
+            if (null !== selectedText) {
+                this.registersStorage[registerName] = RegisterContent.fromRegion(selectedText);
+            }
+        }
+        return;
+    }
 
-	restoreTextFromRegister(registerName: string): void {
-		vscode.commands.executeCommand("emacs.exitMarkMode"); // emulate Emacs
-		let obj : RegisterContent = this.registersStorage[registerName];
-		if (null === obj) {
-			this.setStatusBarMessage("Register does not contain text.");
-			return;
-		}
-		if (RegisterKind.KText === obj.getRegisterKind()) {
-			const content : string | vscode.Position | RectangleContent = obj.getRegisterContent();
-			if (typeof content === 'string') {
-				vscode.window.activeTextEditor.edit(editBuilder => {
-					editBuilder.insert(this.getSelection().active, content);
-				});
-			}
-		}
-		return;
-	}
+    restoreTextFromRegister(registerName: string): void {
+        vscode.commands.executeCommand("emacs.exitMarkMode"); // emulate Emacs
+        let obj: RegisterContent = this.registersStorage[registerName];
+        if (null === obj) {
+            this.setStatusBarMessage("Register does not contain text.");
+            return;
+        }
+        if (RegisterKind.KText === obj.getRegisterKind()) {
+            const content: string | vscode.Position | RectangleContent = obj.getRegisterContent();
+            if (typeof content === 'string') {
+                vscode.window.activeTextEditor.edit(editBuilder => {
+                    editBuilder.insert(this.getSelection().active, content);
+                });
+            }
+        }
+        return;
+    }
 
-	deleteLine() : void {
-		vscode.commands.executeCommand("emacs.exitMarkMode"); // emulate Emacs
-		vscode.commands.executeCommand("editor.action.deleteLines");
-	}
+    deleteLine(): void {
+        vscode.commands.executeCommand("emacs.exitMarkMode"); // emulate Emacs
+        vscode.commands.executeCommand("editor.action.deleteLines");
+    }
 
-	scrollLineToCenter() {
-		const editor = vscode.window.activeTextEditor
-		const selection = editor.selection
-		const range = new vscode.Range(selection.start, selection.end)
-		editor.revealRange(range, vscode.TextEditorRevealType.InCenter)
-	}
+    scrollLineToCenter() {
+        const editor = vscode.window.activeTextEditor
+        const selection = editor.selection
+        const range = new vscode.Range(selection.start, selection.end)
+        editor.revealRange(range, vscode.TextEditorRevealType.InCenter)
+    }
 
-	breakLine() {
-		vscode.commands.executeCommand("lineBreakInsert");
-		vscode.commands.executeCommand("emacs.cursorHome");
-		vscode.commands.executeCommand("emacs.cursorDown");
-	}
+    breakLine() {
+        vscode.commands.executeCommand("lineBreakInsert");
+        vscode.commands.executeCommand("emacs.cursorHome");
+        vscode.commands.executeCommand("emacs.cursorDown");
+    }
 
-	enterMarkMode() :void {
-		if (Editor.inMarkMode && !Editor.markHasMoved) {
-			this.exitMarkMode();
-		} else {
-			this.positions.push(vscode.window.activeTextEditor.selection.active)
-			this.exitMarkMode();
-			Editor.inMarkMode = true;
-			Editor.markHasMoved = false;
-		}
-	}
+    enterMarkMode(): void {
+        if (Editor.inMarkMode && !Editor.markHasMoved) {
+            this.exitMarkMode();
+        } else {
+            this.positions.push(vscode.window.activeTextEditor.selection.active)
+            this.exitMarkMode();
+            Editor.inMarkMode = true;
+            Editor.markHasMoved = false;
+        }
+    }
 
-	exitMarkMode() : void {
-		vscode.commands.executeCommand("cancelSelection");
-		Editor.inMarkMode = false;
-	}
+    exitMarkMode(): void {
+        vscode.commands.executeCommand("cancelSelection");
+        Editor.inMarkMode = false;
+    }
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -109,7 +109,7 @@ export class Editor {
 	}
 
 	copy(): void {
-		clip.writeSync(this.getSelectionText())
+		vscode.commands.executeCommand("editor.action.clipboardCopyAction")
 		vscode.commands.executeCommand("emacs.exitMarkMode")
 	}
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -117,7 +117,7 @@ export class Editor {
     }
 
     // Kill to end of line
-    killForward(): void {
+    killLineForward(): void {
         // Ignore whatever we have selected before
         vscode.commands.executeCommand("emacs.exitMarkMode")
         // move cursor to the end of the line and select the text
@@ -131,7 +131,7 @@ export class Editor {
     }
 
     // Kill to beginning of line
-    killBackward(): void {
+    killLineBackward(): void {
         // Ignore whatever we have selected before
         vscode.commands.executeCommand("emacs.exitMarkMode")
         // move cursor to the beginning of the line and select the text

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -348,7 +348,7 @@ export class Editor {
 
     deleteLine(): void {
         vscode.commands.executeCommand("emacs.exitMarkMode"); // emulate Emacs
-        vscode.commands.executeCommand("editor.action.deleteLines");
+        vscode.commands.executeCommand("editor.action.clipboardCutAction")
     }
 
     scrollLineToCenter() {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -93,6 +93,7 @@ export class Editor {
 	killForward(): void {
 		// Ignore whatever we have selected before
 		vscode.commands.executeCommand("emacs.exitMarkMode")
+		// move cursor to the end of the line and select the text
 		vscode.commands.executeCommand("cursorMove", {
 			to:"wrappedLineEnd",
 			select:true
@@ -100,6 +101,20 @@ export class Editor {
 		// editor.action.clipboardCutAction is too slow!
 		vscode.commands.executeCommand("editor.action.clipboardCopyAction");
 		vscode.commands.executeCommand("deleteAllRight");
+	}
+
+	// Kill to beginning of line
+	killBackward(): void {
+		// Ignore whatever we have selected before
+		vscode.commands.executeCommand("emacs.exitMarkMode")
+		// move cursor to the beginning of the line and select the text
+		vscode.commands.executeCommand("cursorMove", {
+			to:"wrappedLineStart",
+			select:true
+		})
+		// editor.action.clipboardCutAction is too slow!
+		vscode.commands.executeCommand("editor.action.clipboardCopyAction");
+		vscode.commands.executeCommand("deleteAllLeft");
 	}
 
 	copy(): void {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -56,7 +56,7 @@ export class Editor {
 		return vscode.window.activeTextEditor.selection.active.line == vscode.window.activeTextEditor.document.lineCount - 1
 	}
 
-	goBack() : void {
+	goBack(select : boolean) : void {
 		if (this.positions.length > 0) {
 			var jumpPosition = this.positions.pop()
 			var currentPosition = vscode.window.activeTextEditor.selection.active;
@@ -65,16 +65,19 @@ export class Editor {
 				vscode.commands.executeCommand("cursorMove", {
 					to:"down",
 					value:jumpPosition.line - currentPosition.line,
+					select:select
 				})
 			}
 
 			vscode.commands.executeCommand("cursorMove", {
 				to:"wrappedLineStart",
+				select:select
 			})
 
 			vscode.commands.executeCommand("cursorMove", {
 				to:"right",
 				value:jumpPosition.character,
+				select:select
 			})
 		}
 	}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -90,7 +90,7 @@ export class Editor {
 	}
 
 	// Kill to end of line
-	kill(): void {
+	killForward(): void {
 		// Ignore whatever we have selected before
 		vscode.commands.executeCommand("emacs.exitMarkMode")
 		vscode.commands.executeCommand("cursorMove", {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -56,10 +56,6 @@ export class Editor {
 		return vscode.window.activeTextEditor.selection.active.line == vscode.window.activeTextEditor.document.lineCount - 1
 	}
 
-	apendPosition(position: vscode.Position) : void {
-		this.positions.push(position)
-	}
-
 	goBack() : void {
 		if (this.positions.length > 0) {
 			var jumpPosition = this.positions.pop()

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -346,7 +346,7 @@ export class Editor {
         return;
     }
 
-    deleteLine(): void {
+    killWholeLine(): void {
         vscode.commands.executeCommand("emacs.exitMarkMode"); // emulate Emacs
         vscode.commands.executeCommand("editor.action.clipboardCutAction")
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,11 @@
 import * as vscode from 'vscode';
 import {Operation} from './operation';
+import {Editor} from "./editor";
 
-var inMarkMode: boolean = false;
-var markHasMoved: boolean = false;
 export function activate(context: vscode.ExtensionContext): void {
     let op = new Operation(),
         commandList: string[] = [
-            "C-g",
+            "C-g", "enterMarkMode", "exitMarkMode",
 
             // Edit
             "C-k", "C-w", "M-w", "C-y", "C-x_C-o",
@@ -33,11 +32,9 @@ export function activate(context: vscode.ExtensionContext): void {
     cursorMoves.forEach(element => {
         context.subscriptions.push(vscode.commands.registerCommand(
             "emacs."+element, () => {
-                if (inMarkMode) {
-                    markHasMoved  = true;
-                }
+                Editor.setMarkHasMoved(true);
                 vscode.commands.executeCommand(
-                    inMarkMode ?
+                    Editor.getInMarkMode() ?
                     element+"Select" :
                     element
                 );
@@ -52,41 +49,11 @@ export function activate(context: vscode.ExtensionContext): void {
 		}
 		op.onType(args.text);
     }));
-
-    initMarkMode(context);
 }
 
 export function deactivate(): void {
 }
 
-function initMarkMode(context: vscode.ExtensionContext): void {
-    context.subscriptions.push(vscode.commands.registerCommand(
-        'emacs.enterMarkMode', () => {
-            if (inMarkMode && !markHasMoved) {
-                inMarkMode = false;
-            } else {
-                initSelection();
-                inMarkMode = true;
-                markHasMoved = false;
-            }
-        })
-    );
-
-    context.subscriptions.push(vscode.commands.registerCommand(
-        'emacs.exitMarkMode', () => {
-            vscode.commands.executeCommand("cancelSelection");
-            if (inMarkMode) {
-                inMarkMode = false;
-            }
-        })
-    );
-}
-
 function registerCommand(commandName: string, op: Operation): vscode.Disposable {
     return vscode.commands.registerCommand("emacs." + commandName, op.getCommand(commandName));
-}
-
-function initSelection(): void {
-    var currentPosition: vscode.Position = vscode.window.activeTextEditor.selection.active;
-    vscode.window.activeTextEditor.selection = new vscode.Selection(currentPosition, currentPosition);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ export function activate(context: vscode.ExtensionContext): void {
             "C-x_C-o", "C-x_u", "C-/", "C-j", "C-S_bs",
 
             // Navigation
-            "C-l", "C-u_C-spc",
+            "C-l", "C-u_C-spc", "C-x_C-x",
 
             // R-Mode
             "C-x_r"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,8 +8,8 @@ export function activate(context: vscode.ExtensionContext): void {
             "C-g", "enterMarkMode", "exitMarkMode",
 
             // Edit
-            "C-k", "C-w", "M-w", "C-y", "C-x_C-o",
-            "C-x_u", "C-/", "C-j", "C-S_bs",
+            "C-k", "M-0_C-k", "C-w", "M-w", "C-y",
+            "C-x_C-o", "C-x_u", "C-/", "C-j", "C-S_bs",
 
             // Navigation
             "C-l",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import {Operation} from './operation';
-import {Editor} from "./editor";
+import { Operation } from './operation';
+import { Editor } from "./editor";
 
 export function activate(context: vscode.ExtensionContext): void {
     let op = new Operation(),
@@ -31,12 +31,12 @@ export function activate(context: vscode.ExtensionContext): void {
 
     cursorMoves.forEach(element => {
         context.subscriptions.push(vscode.commands.registerCommand(
-            "emacs."+element, () => {
+            "emacs." + element, () => {
                 Editor.setMarkHasMoved(true);
                 vscode.commands.executeCommand(
                     Editor.getInMarkMode() ?
-                    element+"Select" :
-                    element
+                        element + "Select" :
+                        element
                 );
             })
         )
@@ -44,10 +44,10 @@ export function activate(context: vscode.ExtensionContext): void {
 
     // 'type' is not an "emacs." command and should be registered separately
     context.subscriptions.push(vscode.commands.registerCommand("type", function (args) {
-		if (!vscode.window.activeTextEditor) {
-			return;
-		}
-		op.onType(args.text);
+        if (!vscode.window.activeTextEditor) {
+            return;
+        }
+        op.onType(args.text);
     }));
 }
 

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -14,10 +14,10 @@ export class Operation {
                 this.editor.exitMarkMode()
             },
             'C-k': () => {
-                this.editor.killForward();
+                this.editor.killLineForward();
             },
             'M-0_C-k': () => {
-                this.editor.killBackward();
+                this.editor.killLineBackward();
             },
             'C-w': () => {
                 this.editor.cut()

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -55,7 +55,10 @@ export class Operation {
                 this.editor.scrollLineToCenter()
             },
             'C-u_C-spc': () => {
-                this.editor.goBack()
+                this.editor.goBack(false)
+            },
+            'C-x_C-x': () => {
+                this.editor.goBack(true)
             }
         };
     }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -46,7 +46,7 @@ export class Operation {
                 this.editor.setStatusBarMessage("Quit");
             },
             "C-S_bs": () => {
-                this.editor.deleteLine();
+                this.editor.killWholeLine();
             },
             "C-x_r": () => {
                 this.editor.setRMode();

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -7,6 +7,12 @@ export class Operation {
     constructor() {
         this.editor = new Editor();
         this.commandList = {
+            "enterMarkMode": () => {
+                this.editor.enterMarkMode()
+            },
+            "exitMarkMode": () => {
+                this.editor.exitMarkMode()
+            },
             'C-k': () => {
                 this.editor.kill();
             },

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -1,4 +1,4 @@
-import {Editor} from './editor';
+import { Editor } from './editor';
 
 export class Operation {
     private editor: Editor;

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -16,6 +16,9 @@ export class Operation {
             'C-k': () => {
                 this.editor.killForward();
             },
+            'M-0_C-k': () => {
+                this.editor.killBackward();
+            },
             'C-w': () => {
                 this.editor.cut()
             },

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -14,7 +14,7 @@ export class Operation {
                 this.editor.exitMarkMode()
             },
             'C-k': () => {
-                this.editor.kill();
+                this.editor.killForward();
             },
             'C-w': () => {
                 this.editor.cut()

--- a/src/registers.ts
+++ b/src/registers.ts
@@ -11,33 +11,33 @@ export class RectangleContent { // TODO: move it to rectangle.ts eventually.
 };
 
 export class RegisterContent {
-    private kind : RegisterKind;
-    private content :   string              // stores region/text
-                        | vscode.Position   // stores position 
-                        | RectangleContent; // stores rectangle
-                        
-    constructor(registerKind : RegisterKind, registerContent : string | vscode.Position | RectangleContent) {
+    private kind: RegisterKind;
+    private content: string              // stores region/text
+                     | vscode.Position   // stores position
+                     | RectangleContent; // stores rectangle
+
+    constructor(registerKind: RegisterKind, registerContent: string | vscode.Position | RectangleContent) {
         this.kind = registerKind;
         this.content = registerContent;
     }
 
-    static fromRegion(registerContent : string) {
+    static fromRegion(registerContent: string) {
         return new this(RegisterKind.KText, registerContent);
     }
 
-    static fromPoint(registerContent : vscode.Position) {
+    static fromPoint(registerContent: vscode.Position) {
         return new this(RegisterKind.KPoint, registerContent);
-    } 
+    }
 
-    static fromRectangle(registerContent : RectangleContent) {
+    static fromRectangle(registerContent: RectangleContent) {
         return new this(RegisterKind.KRectangle, registerContent);
-    } 
+    }
 
-    getRegisterKind() : RegisterKind {
+    getRegisterKind(): RegisterKind {
         return this.kind;
     }
 
-    getRegisterContent() : string | vscode.Position | RectangleContent {
+    getRegisterContent(): string | vscode.Position | RectangleContent {
         return this.content;
     }
 };


### PR DESCRIPTION
Don't know why, but my last 7 commits are listed again, probably you merged them in a non conventional way, or maybe it was my mistake while updating my fork. Anyway, the new modifications are:

* Now copy and cut operations will copy/cut the selected region OR the intire line if no region is selected (just as the original C-c and C-x behaviour)
* Change kill to end of line implementation and add kill to beginning of line. Also, both kill operations will cut the line instead of just deleting it (jus like in emacs)
* Add cursor go back operation with and without selection (C-x C-x  and C-u C-SPC respectively)
* Fix C-f to work as a cursor movement inside integrated terminal
* Adjust some coding styles, like spaces/tabs, missing and trailing spaces, etc
* Now deleteLine will not simply delete the current line, but in fact cut it (just like emacs original behaviour)
* Rename deleteLine and kill functions to match emacs correspondent command name
* Add C-x s shortcut to save all files

Some modifications in the code were necessary, like moving enterMarkMode and exitMarkMode to Editor class. Also, the markMode logic has changed: no more `initSelection()` call, just your `vscode.commands.executeCommand(
                    Editor.getInMarkMode() ?
                    element+"Select" :
                    element
                );` is enough. Other minor improvements in the code were performed as well.