### PR TITLE
Extend C-l to position cursor at center/top/bottom

### DIFF
--- a/src/operation.ts
+++ b/src/operation.ts
@@ -43,7 +43,7 @@ export class Operation {
                 this.editor.setRMode();
             },
             'C-l': () => {
-                this.editor.scrollLineToCenter()
+                this.editor.scrollLineToCenterTopBottom()
             }
         };
     }


### PR DESCRIPTION
This extends C-l to cycle between positioning the current line at the middle/top/bottom of the screen, matching the behaviour in Emacs.