### PR TITLE
Origin/terminal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The following are some of the changes and enhancements from the original:
 * C+l centers screen on the cursor line
 * C+x C+f bound to quick open file
 * yank overwrites selection
-
+* Terminal access using `M-!` (Alt+Shift+1)
 
 ### Move commands
 |Command | Desc |
@@ -109,6 +109,16 @@ The following are some of the changes and enhancements from the original:
 - `ctrl+/`: editor.action.commentLine => **Use `ctrl+;` instead**;
 - `ctrl+p` & `ctrl+e`: workbench.action.quickOpen => **Use `ctrl+x b` instead**;
 - `ctrl+p`: workbench.action.quickOpenNavigateNext => **Use `ctrl+n` instead**.
+
+
+## Activate the alt+shift+1 **Terminal support**
+In order to toggle the "minibuffer" terminal, add this to your `settings.json` :
+```
+"terminal.integrated.commandsToSkipShell": [
+  "emacs.shellCommand"
+]
+```
+Now you can toggle a terminal using `alt+shift+1`, just like in Emacs for quick access.
 
 # More information
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The following are some of the changes and enhancements from the original:
 
 ## Activate the alt+shift+1 **Terminal support**
 In order to toggle the "minibuffer" terminal, add this to your `settings.json` :
-```
+```json
 "terminal.integrated.commandsToSkipShell": [
   "emacs.shellCommand"
 ]

--- a/package.json
+++ b/package.json
@@ -197,6 +197,10 @@
                 "when": "editorFocus && findWidgetVisible"
             },
             {
+                "key": "alt+shift+1",
+                "command": "emacs.shellCommand"
+            },
+            {
                 "key": "alt+g g",
                 "command": "workbench.action.gotoLine"
             },

--- a/package.json
+++ b/package.json
@@ -249,6 +249,16 @@
                 "when": "editorFocus"
             },
             {
+                "key": "backspace",
+                "command": "emacs.deleteLeft",
+                "when": "editorTextFocus && !editorReadonly"
+            },
+            {
+                "key": "delete",
+                "command": "emacs.deleteRight",
+                "when": "editorTextFocus && !editorReadonly"
+            },
+            {
                 "key": "ctrl+d",
                 "command": "deleteRight",
                 "when": "editorTextFocus && !editorReadonly"

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -189,6 +189,36 @@ export class Editor {
 		vscode.commands.executeCommand("editor.action.deleteLines");
 	}
 
+
+	/**
+	 * The <backspace> and <delete> keys should always leave
+	 * the MarkMode whenever.
+	 */
+	deleteLeft() : void {
+		const selectionText = this.getSelectionText();
+		// if nothing is selected we should deleteLeft
+		if (selectionText.length == 0) {
+			vscode.commands.executeCommand('deleteLeft');
+		} else {
+			// or else we delete the selection
+			Editor.delete(this.getSelectionRange());
+		}
+		// in both case we should leave the MarkMode (this is very important)
+		vscode.commands.executeCommand('emacs.exitMarkMode');
+	}
+	deleteRight() : void {
+		const selectionText = this.getSelectionText();
+		// if nothing is selected we should deleteRight
+		if (selectionText.length == 0) {
+			vscode.commands.executeCommand('deleteRight');
+		} else {
+			// or else we delete the selection
+			Editor.delete(this.getSelectionRange());
+		}
+		// in both case we should leave the MarkMode (this is very important)
+		vscode.commands.executeCommand('emacs.exitMarkMode');
+	}
+
 	scrollLineToCenterTopBottom = () => {
 		const editor = vscode.window.activeTextEditor
 		const selection = editor.selection

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ export function activate(context: vscode.ExtensionContext): void {
             "deleteLeft", "deleteRight",
 
             // Navigation
-            "C-l"
+            "C-l", "shellCommand"
         ],
         cursorMoves: string[] = [
             "cursorUp", "cursorDown", "cursorLeft", "cursorRight",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,9 +11,10 @@ export function activate(context: vscode.ExtensionContext): void {
             // Edit
             "C-k", "C-w", "M-w", "C-y", "C-x_C-o",
             "C-x_u", "C-/", "C-j", "C-S_bs",
+            "deleteLeft", "deleteRight",
 
             // Navigation
-            "C-l",
+            "C-l"
         ],
         cursorMoves: string[] = [
             "cursorUp", "cursorDown", "cursorLeft", "cursorRight",

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -41,7 +41,9 @@ export class Operation {
             },
             'C-l': () => {
                 this.editor.scrollLineToCenterTopBottom()
-            }
+            },
+            'deleteLeft': () => {this.editor.deleteLeft()},
+            'deleteRight': () => {this.editor.deleteRight()}
         };
     }
 

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -1,11 +1,15 @@
 import {Editor} from './editor';
+import {Workspace} from './workspace';
 
 export class Operation {
     private editor: Editor;
+    private workspace: Workspace;
     private commandList: { [key: string]: (...args: any[]) => any, thisArgs?: any } = {};
 
     constructor() {
         this.editor = new Editor();
+        this.workspace = new Workspace();
+
         this.commandList = {
             'C-k': () => {
                 this.editor.kill();
@@ -43,7 +47,9 @@ export class Operation {
                 this.editor.scrollLineToCenterTopBottom()
             },
             'deleteLeft': () => {this.editor.deleteLeft()},
-            'deleteRight': () => {this.editor.deleteRight()}
+            'deleteRight': () => {this.editor.deleteRight()},
+
+            'shellCommand': () => {this.workspace.toggleTerminal()}
         };
     }
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,0 +1,51 @@
+import * as vscode from "vscode";
+
+
+export class Workspace {
+    private static terminal: Terminal;
+
+    constructor() {
+        if (!Workspace.terminal) {
+            Workspace.terminal = new Terminal();
+        }
+    }
+
+    showTerminal() {
+        Workspace.terminal.show();
+    }
+    hideTerminal() {
+        Workspace.terminal.hide();
+    }
+    toggleTerminal() {
+        Workspace.terminal.toggle();
+    }
+}
+
+
+class Terminal {
+  private _terminal: vscode.Terminal;
+  private _visible: boolean;
+
+  constructor() {
+    this._terminal = vscode.window.createTerminal('minibuffer');
+    // when the workspace opens, we don't show the terminal
+    this._visible = false;
+  }
+
+  show() {
+    this._terminal.show();
+    this._visible = true;
+  }
+
+  hide() {
+    this._terminal.hide();
+    this._visible = false;
+  }
+  toggle() {
+    if (this._visible)
+      this.hide();
+    else {
+      this.show();
+    }
+  }
+}


### PR DESCRIPTION
In addition to the previous pull request, I propose this terminal support.

In Emacs alt+shift+1 (M-!) will run the command shell-command in the minibuffer. There is no minibuffer in vscode but I tried to emulate this behavior with a terminal I call "minibuffer" and attach to the Terminal pane. If you like the addition, you can ignore my previous PR and merge this one.