### PR TITLE
#41 async killing causes some lines to get missed

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -12,6 +12,7 @@ export class Editor {
 	private lastKill: vscode.Position // if kill position stays the same, append to clipboard
 	private justDidKill: boolean
 	private centerState: RecenterPosition
+	private killInProgress: boolean
 
 	constructor() {
 		this.justDidKill = false
@@ -72,6 +73,10 @@ export class Editor {
 
 	// Kill to end of line
 	async kill(): Promise<boolean> {
+		if (this.killInProgress) {
+			return null;
+		}
+		this.killInProgress = true
 		// Ignore whatever we have selected before
 		await vscode.commands.executeCommand("emacs.exitMarkMode")
 
@@ -101,6 +106,7 @@ export class Editor {
 		promise.then(() => {
 			this.justDidKill = true
 			this.lastKill = startPos
+			this.killInProgress = false
 		})
 
 		return promise


### PR DESCRIPTION
#41 Not sure if this is the best way to enforce a mutex here. Basically we only want one kill command to be operational at one time.