### PR TITLE
Add general keybindings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
                 "when": "terminalFocus"
             },
             {
+                "key": "ctrl+f",
+                "command": "closeFindWidget",
+                "when": "editorFocus && findWidgetVisible"
+            },
+            {
                 "key": "left",
                 "command": "emacs.cursorLeft",
                 "when": "editorTextFocus"
@@ -55,6 +60,11 @@
                 "key": "ctrl+b",
                 "command": "emacs.cursorLeft",
                 "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+b",
+                "command": "closeFindWidget",
+                "when": "editorFocus && findWidgetVisible"
             },
             {
                 "key": "up",
@@ -112,6 +122,11 @@
                 "when": "editorTextFocus"
             },
             {
+                "key": "ctrl+a",
+                "command": "closeFindWidget",
+                "when": "editorFocus && findWidgetVisible"
+            },
+            {
                 "key": "end",
                 "command": "emacs.cursorEnd",
                 "when": "editorTextFocus"
@@ -125,6 +140,11 @@
                 "key": "ctrl+e",
                 "command": "emacs.cursorEnd",
                 "when": "terminalFocus"
+            },
+            {
+                "key": "ctrl+e",
+                "command": "closeFindWidget",
+                "when": "editorFocus && findWidgetVisible"
             },
             {
                 "key": "alt+f",

--- a/package.json
+++ b/package.json
@@ -265,6 +265,11 @@
             },
             {
                 "key": "ctrl+s",
+                "command": "actions.find",
+                "when": "textInputFocus && findWidgetVisible"
+            },
+            {
+                "key": "ctrl+s",
                 "command": "editor.action.nextMatchFindAction",
                 "when": "findWidgetVisible"
             },
@@ -272,6 +277,11 @@
                 "key": "ctrl+r",
                 "command": "actions.find",
                 "when": "!findWidgetVisible"
+            },
+            {
+                "key": "ctrl+r",
+                "command": "actions.find",
+                "when": "textInputFocus && findWidgetVisible"
             },
             {
                 "key": "ctrl+r",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
             },
             {
                 "key": "ctrl+b",
+                "command": "emacs.cursorLeft",
+                "when": "terminalFocus"
+            },
+            {
+                "key": "ctrl+b",
                 "command": "closeFindWidget",
                 "when": "editorFocus && findWidgetVisible"
             },
@@ -108,6 +113,11 @@
             },
             {
                 "key": "ctrl+n",
+                "command": "emacs.cursorDown",
+                "when": "terminalFocus"
+            },
+            {
+                "key": "ctrl+n",
                 "command": "closeFindWidget",
                 "when": "editorFocus && findWidgetVisible"
             },
@@ -120,6 +130,11 @@
                 "key": "ctrl+a",
                 "command": "emacs.cursorHome",
                 "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+a",
+                "command": "emacs.cursorHome",
+                "when": "terminalFocus"
             },
             {
                 "key": "ctrl+a",


### PR DESCRIPTION
Add keybindings that seem to be missing. I think these are generally useful.

- Add close find widget with ctrl+f,b,a,e.
- Add ctrl+b,n,a as cursor command "when" terminal focus.
ctrl+f,p,e already exists.
- Add focus on find widget with ctrl+s,r "when" the widget does not have focus.
