### PR TITLE
Ctrl-o open line

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following are some of the changes and enhancements from the original:
 | `M-Bksp` | Delete word left |
 | `C-k` | Kill to line end |
 | `C-S-Bksp` | Kill entire line |
+| `C-o` | open-line |
 | `C-w` | Kill region |
 | `M-w` | Copy region to kill ring |
 | `C-y` | Yank |
@@ -109,7 +110,7 @@ The following are some of the changes and enhancements from the original:
 - `ctrl+/`: editor.action.commentLine => **Use `ctrl+;` instead**;
 - `ctrl+p` & `ctrl+e`: workbench.action.quickOpen => **Use `ctrl+x b` instead**;
 - `ctrl+p`: workbench.action.quickOpenNavigateNext => **Use `ctrl+n` instead**.
-
+- `ctrl-o`: workbench.action.files.openFile => **Use `ctrl+x ctrl+f` instead**.
 # More information
 
 The logo is from the great [Pacifica Icon Set](http://bokehlicia.deviantart.com/art/Pacifica-Icons-402508559).

--- a/package.json
+++ b/package.json
@@ -1,622 +1,627 @@
 {
-    "name": "vscode-emacs-friendly",
-    "displayName": "Emacs Friendly Keymap",
-    "description": "Emacs keybindings and selection, friendly interaction with the system clipboard.",
-    "icon": "emacs_pacifica.png",
-    "version": "0.8.2",
-    "publisher": "lfs",
-    "homepage": "https://github.com/SebastianZaha/vscode-emacs-friendly",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/SebastianZaha/vscode-emacs-friendly"
-    },
-    "bugs": "https://github.com/SebastianZaha/vscode-emacs-friendly/issues",
-    "engines": {
-        "vscode": "^1.11.0"
-    },
-    "categories": [
-        "Other",
-        "Keymaps"
-    ],
-    "keywords": [
-        "emacs",
-        "shortcuts",
-        "keybindings",
-        "behavior",
-        "selection"
-    ],
-    "activationEvents": [
-        "*"
-    ],
-    "main": "./out/src/extension",
-    "contributes": {
-        "keybindings": [
-            {
-                "key": "right",
-                "command": "emacs.cursorRight",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+f",
-                "command": "emacs.cursorRight",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+f",
-                "command": "emacs.cursorRight",
-                "when": "terminalFocus"
-            },
-            {
-                "key": "left",
-                "command": "emacs.cursorLeft",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+b",
-                "command": "emacs.cursorLeft",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "up",
-                "command": "emacs.cursorUp",
-                "when": "editorTextFocus && !suggestWidgetVisible"
-            },
-            {
-                "key": "up",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+p",
-                "command": "emacs.cursorUp",
-                "when": "editorTextFocus && !suggestWidgetVisible"
-            },
-            {
-                "key": "ctrl+p",
-                "command": "emacs.cursorUp",
-                "when": "terminalFocus"
-            },
-            {
-                "key": "ctrl+p",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "down",
-                "command": "emacs.cursorDown",
-                "when": "editorTextFocus && !suggestWidgetVisible"
-            },
-            {
-                "key": "down",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+n",
-                "command": "emacs.cursorDown",
-                "when": "editorTextFocus && !suggestWidgetVisible"
-            },
-            {
-                "key": "ctrl+n",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "home",
-                "command": "emacs.cursorHome",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+a",
-                "command": "emacs.cursorHome",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "end",
-                "command": "emacs.cursorEnd",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+e",
-                "command": "emacs.cursorEnd",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+e",
-                "command": "emacs.cursorEnd",
-                "when": "terminalFocus"
-            },
-            {
-                "key": "alt+f",
-                "command": "emacs.cursorWordRight",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "alt+b",
-                "command": "emacs.cursorWordLeft",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "pagedown",
-                "command": "emacs.cursorPageDown",
-                "when": "editorTextFocus && !suggestWidgetVisible"
-            },
-            {
-                "key": "pagedown",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+v",
-                "command": "emacs.cursorPageDown",
-                "when": "editorTextFocus && !suggestWidgetVisible"
-            },
-            {
-                "key": "ctrl+v",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "pageup",
-                "command": "emacs.cursorPageUp",
-                "when": "editorTextFocus && !suggestWidgetVisible"
-            },
-            {
-                "key": "pageup",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "alt+v",
-                "command": "emacs.cursorPageUp",
-                "when": "editorTextFocus && !suggestWidgetVisible"
-            },
-            {
-                "key": "alt+v",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "alt+shift+.",
-                "command": "emacs.cursorBottom",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "alt+shift+.",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "alt+shift+,",
-                "command": "emacs.cursorTop",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "alt+shift+,",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "alt+g g",
-                "command": "workbench.action.gotoLine"
-            },
-            {
-                "key": "alt+g n",
-                "command": "editor.action.marker.next"
-            },
-            {
-                "key": "alt+g p",
-                "command": "editor.action.marker.prev"
-            },
-            {
-                "key": "alt+g g",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+s",
-                "command": "actions.find",
-                "when": "!findWidgetVisible"
-            },
-            {
-                "key": "alt+shift+5",
-                "command": "editor.action.startFindReplaceAction",
-                "when": "editorFocus"
-            },
-            {
-                "command": "editor.action.replaceOne",
-                "key": "ctrl+enter",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+s",
-                "command": "editor.action.nextMatchFindAction",
-                "when": "findWidgetVisible"
-            },
-            {
-                "key": "ctrl+r",
-                "command": "actions.find",
-                "when": "!findWidgetVisible"
-            },
-            {
-                "key": "ctrl+r",
-                "command": "editor.action.previousMatchFindAction",
-                "when": "findWidgetVisible"
-            },
-            {
-                "key": "ctrl+alt+n",
-                "command": "editor.action.addSelectionToNextFindMatch",
-                "when": "editorFocus"
-            },
-            {
-                "key": "ctrl+d",
-                "command": "deleteRight",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "ctrl+h",
-                "command": "deleteLeft",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "alt+d",
-                "command": "deleteWordRight",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "ctrl+k",
-                "command": "emacs.C-k",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "ctrl+w",
-                "command": "emacs.C-w",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "ctrl+w",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "alt+w",
-                "command": "emacs.M-w",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "alt+w",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+y",
-                "command": "emacs.C-y",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "ctrl+y",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+m",
-                "command": "emacs.C-j",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "ctrl+j",
-                "command": "emacs.C-j",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "ctrl+j",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+x ctrl+o",
-                "command": "emacs.C-x_C-o",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "ctrl+x ctrl+o",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+x h",
-                "command": "editor.action.selectAll",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+x h",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+x u",
-                "command": "emacs.C-x_u",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "ctrl+x u",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+x z",
-                "command": "workbench.action.toggleZenMode"
-            },
-            {
-                "key": "ctrl+/",
-                "command": "emacs.C-/",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "ctrl+/",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+;",
-                "command": "editor.action.commentLine",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "ctrl+;",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "alt+;",
-                "command": "editor.action.blockComment",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "alt+;",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+l",
-                "command": "emacs.C-l",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "emacs.C-g",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "closeFindWidget",
-                "when": "editorFocus && findWidgetVisible"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "emacs.exitMarkMode",
-                "when": "editorTextFocus && editorHasSelection"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "closeReferenceSearchEditor",
-                "when": "inReferenceSearchEditor && !config.editor.stablePeek"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "closeReferenceSearch",
-                "when": "referenceSearchVisible && !config.editor.stablePeek"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "removeSecondaryCursors",
-                "when": "editorHasMultipleSelections && editorTextFocus"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "closeBreakpointWidget",
-                "when": "breakpointWidgetVisible && editorFocus"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "leaveSnippet",
-                "when": "editorTextFocus && inSnippetMode"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "closeMarkersNavigation",
-                "when": "editorFocus && markersNavigationVisible"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "closeParameterHints",
-                "when": "editorTextFocus && parameterHintsVisible"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "hideSuggestWidget",
-                "when": "editorTextFocus && suggestWidgetVisible"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "cancelRenameInput",
-                "when": "editorFocus && renameInputVisible"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "closeAccessibilityHelp",
-                "when": "accessibilityHelpWidgetVisible && editorFocus"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "closeReplaceInFilesWidget",
-                "when": "replaceInputBoxFocus && searchViewletVisible"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "workbench.action.closeMessages",
-                "when": "globalMessageVisible"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "workbench.action.closeQuickOpen",
-                "when": "inQuickOpen"
-            },
-            {
-                "key": "ctrl+space",
-                "command": "emacs.enterMarkMode",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+x ctrl+f",
-                "command": "workbench.action.quickOpen"
-            },
-            {
-                "key": "ctrl+x ctrl+s",
-                "command": "workbench.action.files.save",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+x ctrl+w",
-                "command": "workbench.action.files.saveAs",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+x k",
-                "command": "workbench.action.closeActiveEditor"
-            },
-            {
-                "key": "ctrl+x ctrl-k",
-                "command": "workbench.action.closeAllEditors"
-            },
-            {
-                "key": "ctrl+x k",
-                "command": "workbench.action.closeWindow",
-                "when": "!editorIsOpen"
-            },
-            {
-                "key": "ctrl+x ctrl+n",
-                "command": "workbench.action.newWindow"
-            },
-            {
-                "key": "ctrl+x 1",
-                "command": "workbench.action.closeEditorsInOtherGroups"
-            },
-            {
-                "key": "ctrl+x 2",
-                "command": "workbench.action.splitEditor"
-            },
-            {
-                "key": "ctrl+x 3",
-                "command": "workbench.action.toggleEditorGroupLayout"
-            },
-            {
-                "key": "ctrl+x o",
-                "command": "workbench.action.navigateEditorGroups"
-            },
-            {
-                "key": "ctrl+p",
-                "command": "showPrevParameterHint",
-                "when": "editorTextFocus && parameterHintsVisible"
-            },
-            {
-                "key": "ctrl+n",
-                "command": "showNextParameterHint",
-                "when": "editorTextFocus && parameterHintsVisible"
-            },
-            {
-                "key": "ctrl+p",
-                "command": "selectPrevQuickFix",
-                "when": "editorFocus && quickFixWidgetVisible"
-            },
-            {
-                "key": "ctrl+n",
-                "command": "selectNextQuickFix",
-                "when": "editorFocus && quickFixWidgetVisible"
-            },
-            {
-                "key": "ctrl+p",
-                "command": "selectPrevSuggestion",
-                "when": "editorTextFocus && suggestWidgetVisible"
-            },
-            {
-                "key": "ctrl+n",
-                "command": "selectNextSuggestion",
-                "when": "editorTextFocus && suggestWidgetVisible"
-            },
-            {
-                "key": "ctrl+p",
-                "command": "workbench.action.quickOpenNavigatePrevious",
-                "when": "inQuickOpen"
-            },
-            {
-                "key": "ctrl+n",
-                "command": "workbench.action.quickOpenNavigateNext",
-                "when": "inQuickOpen"
-            },
-            {
-                "key": "ctrl+'",
-                "command": "editor.action.triggerSuggest",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+'",
-                "command": "toggleSuggestionDetails",
-                "when": "editorTextFocus && suggestWidgetVisible"
-            },
-            {
-                "key": "ctrl+shift+'",
-                "command": "editor.action.triggerParameterHints",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "alt+x",
-                "command": "workbench.action.showCommands"
-            },
-            {
-                "key": "ctrl+alt+space",
-                "command": "workbench.action.toggleSidebarVisibility"
-            },
-            {
-                "key": "ctrl+x b",
-                "command": "workbench.action.showAllEditors"
-            },
-            {
-                "key": "ctrl+shift+backspace",
-                "command": "emacs.C-S_bs",
-                "when": "editorTextFocus"
-            },
-            {
-                "key": "ctrl+x ctrl+l",
-                "command": "editor.action.transformToLowercase",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "ctrl+x ctrl+u",
-                "command": "editor.action.transformToUppercase",
-                "when": "editorTextFocus && !editorReadonly"
-            },
-            {
-                "key": "alt+backspace",
-                "command": "deleteWordLeft",
-                "when": "editorTextFocus && !editorReadonly"
-            }
-        ]
-    },
-    "scripts": {
-        "vscode:prepublish": "tsc -p ./",
-        "compile": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "lint": "tslint -p tslint.json --type-check **/*.ts"
-    },
-    "devDependencies": {
-        "@types/mocha": "^2.2.41",
-        "@types/node": "^6.0.81",
-        "mocha": "^3.4.2",
-        "typescript": "^2.4.1",
-        "vscode": "^1.1.4"
-    },
-    "dependencies": {
-        "clipboardy": "^1.1.4"
-    }
+  "name": "vscode-emacs-friendly",
+  "displayName": "Emacs Friendly Keymap",
+  "description": "Emacs keybindings and selection, friendly interaction with the system clipboard.",
+  "icon": "emacs_pacifica.png",
+  "version": "0.8.2",
+  "publisher": "lfs",
+  "homepage": "https://github.com/SebastianZaha/vscode-emacs-friendly",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SebastianZaha/vscode-emacs-friendly"
+  },
+  "bugs": "https://github.com/SebastianZaha/vscode-emacs-friendly/issues",
+  "engines": {
+    "vscode": "^1.11.0"
+  },
+  "categories": [
+    "Other",
+    "Keymaps"
+  ],
+  "keywords": [
+    "emacs",
+    "shortcuts",
+    "keybindings",
+    "behavior",
+    "selection"
+  ],
+  "activationEvents": [
+    "*"
+  ],
+  "main": "./out/src/extension",
+  "contributes": {
+    "keybindings": [
+      {
+        "key": "right",
+        "command": "emacs.cursorRight",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+f",
+        "command": "emacs.cursorRight",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+f",
+        "command": "emacs.cursorRight",
+        "when": "terminalFocus"
+      },
+      {
+        "key": "left",
+        "command": "emacs.cursorLeft",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+b",
+        "command": "emacs.cursorLeft",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "up",
+        "command": "emacs.cursorUp",
+        "when": "editorTextFocus && !suggestWidgetVisible"
+      },
+      {
+        "key": "up",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+p",
+        "command": "emacs.cursorUp",
+        "when": "editorTextFocus && !suggestWidgetVisible"
+      },
+      {
+        "key": "ctrl+p",
+        "command": "emacs.cursorUp",
+        "when": "terminalFocus"
+      },
+      {
+        "key": "ctrl+p",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "down",
+        "command": "emacs.cursorDown",
+        "when": "editorTextFocus && !suggestWidgetVisible"
+      },
+      {
+        "key": "down",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+n",
+        "command": "emacs.cursorDown",
+        "when": "editorTextFocus && !suggestWidgetVisible"
+      },
+      {
+        "key": "ctrl+n",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "home",
+        "command": "emacs.cursorHome",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+a",
+        "command": "emacs.cursorHome",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "end",
+        "command": "emacs.cursorEnd",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+e",
+        "command": "emacs.cursorEnd",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+e",
+        "command": "emacs.cursorEnd",
+        "when": "terminalFocus"
+      },
+      {
+        "key": "alt+f",
+        "command": "emacs.cursorWordRight",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "alt+b",
+        "command": "emacs.cursorWordLeft",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "pagedown",
+        "command": "emacs.cursorPageDown",
+        "when": "editorTextFocus && !suggestWidgetVisible"
+      },
+      {
+        "key": "pagedown",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+v",
+        "command": "emacs.cursorPageDown",
+        "when": "editorTextFocus && !suggestWidgetVisible"
+      },
+      {
+        "key": "ctrl+v",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "pageup",
+        "command": "emacs.cursorPageUp",
+        "when": "editorTextFocus && !suggestWidgetVisible"
+      },
+      {
+        "key": "pageup",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "alt+v",
+        "command": "emacs.cursorPageUp",
+        "when": "editorTextFocus && !suggestWidgetVisible"
+      },
+      {
+        "key": "alt+v",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "alt+shift+.",
+        "command": "emacs.cursorBottom",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "alt+shift+.",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "alt+shift+,",
+        "command": "emacs.cursorTop",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "alt+shift+,",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "alt+g g",
+        "command": "workbench.action.gotoLine"
+      },
+      {
+        "key": "alt+g n",
+        "command": "editor.action.marker.next"
+      },
+      {
+        "key": "alt+g p",
+        "command": "editor.action.marker.prev"
+      },
+      {
+        "key": "alt+g g",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+s",
+        "command": "actions.find",
+        "when": "!findWidgetVisible"
+      },
+      {
+        "key": "alt+shift+5",
+        "command": "editor.action.startFindReplaceAction",
+        "when": "editorFocus"
+      },
+      {
+        "command": "editor.action.replaceOne",
+        "key": "ctrl+enter",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+s",
+        "command": "editor.action.nextMatchFindAction",
+        "when": "findWidgetVisible"
+      },
+      {
+        "key": "ctrl+r",
+        "command": "actions.find",
+        "when": "!findWidgetVisible"
+      },
+      {
+        "key": "ctrl+r",
+        "command": "editor.action.previousMatchFindAction",
+        "when": "findWidgetVisible"
+      },
+      {
+        "key": "ctrl+alt+n",
+        "command": "editor.action.addSelectionToNextFindMatch",
+        "when": "editorFocus"
+      },
+      {
+        "key": "ctrl+d",
+        "command": "deleteRight",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "ctrl+h",
+        "command": "deleteLeft",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "alt+d",
+        "command": "deleteWordRight",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "ctrl+k",
+        "command": "emacs.C-k",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "ctrl+w",
+        "command": "emacs.C-w",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "ctrl+w",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "alt+w",
+        "command": "emacs.M-w",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "alt+w",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+y",
+        "command": "emacs.C-y",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "ctrl+y",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+m",
+        "command": "emacs.C-j",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "ctrl+j",
+        "command": "emacs.C-j",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "ctrl+j",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+o",
+        "command": "editor.action.insertLineBefore",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "ctrl+x ctrl+o",
+        "command": "emacs.C-x_C-o",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "ctrl+x ctrl+o",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+x h",
+        "command": "editor.action.selectAll",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+x h",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+x u",
+        "command": "emacs.C-x_u",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "ctrl+x u",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+x z",
+        "command": "workbench.action.toggleZenMode"
+      },
+      {
+        "key": "ctrl+/",
+        "command": "emacs.C-/",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "ctrl+/",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+;",
+        "command": "editor.action.commentLine",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "ctrl+;",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "alt+;",
+        "command": "editor.action.blockComment",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "alt+;",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+l",
+        "command": "emacs.C-l",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "emacs.C-g",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "closeFindWidget",
+        "when": "editorFocus && findWidgetVisible"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "emacs.exitMarkMode",
+        "when": "editorTextFocus && editorHasSelection"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "closeReferenceSearchEditor",
+        "when": "inReferenceSearchEditor && !config.editor.stablePeek"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "closeReferenceSearch",
+        "when": "referenceSearchVisible && !config.editor.stablePeek"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "removeSecondaryCursors",
+        "when": "editorHasMultipleSelections && editorTextFocus"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "closeBreakpointWidget",
+        "when": "breakpointWidgetVisible && editorFocus"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "leaveSnippet",
+        "when": "editorTextFocus && inSnippetMode"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "closeMarkersNavigation",
+        "when": "editorFocus && markersNavigationVisible"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "closeParameterHints",
+        "when": "editorTextFocus && parameterHintsVisible"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "hideSuggestWidget",
+        "when": "editorTextFocus && suggestWidgetVisible"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "cancelRenameInput",
+        "when": "editorFocus && renameInputVisible"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "closeAccessibilityHelp",
+        "when": "accessibilityHelpWidgetVisible && editorFocus"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "closeReplaceInFilesWidget",
+        "when": "replaceInputBoxFocus && searchViewletVisible"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "workbench.action.closeMessages",
+        "when": "globalMessageVisible"
+      },
+      {
+        "key": "ctrl+g",
+        "command": "workbench.action.closeQuickOpen",
+        "when": "inQuickOpen"
+      },
+      {
+        "key": "ctrl+space",
+        "command": "emacs.enterMarkMode",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+x ctrl+f",
+        "command": "workbench.action.quickOpen"
+      },
+      {
+        "key": "ctrl+x ctrl+s",
+        "command": "workbench.action.files.save",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+x ctrl+w",
+        "command": "workbench.action.files.saveAs",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+x k",
+        "command": "workbench.action.closeActiveEditor"
+      },
+      {
+        "key": "ctrl+x ctrl-k",
+        "command": "workbench.action.closeAllEditors"
+      },
+      {
+        "key": "ctrl+x k",
+        "command": "workbench.action.closeWindow",
+        "when": "!editorIsOpen"
+      },
+      {
+        "key": "ctrl+x ctrl+n",
+        "command": "workbench.action.newWindow"
+      },
+      {
+        "key": "ctrl+x 1",
+        "command": "workbench.action.closeEditorsInOtherGroups"
+      },
+      {
+        "key": "ctrl+x 2",
+        "command": "workbench.action.splitEditor"
+      },
+      {
+        "key": "ctrl+x 3",
+        "command": "workbench.action.toggleEditorGroupLayout"
+      },
+      {
+        "key": "ctrl+x o",
+        "command": "workbench.action.navigateEditorGroups"
+      },
+      {
+        "key": "ctrl+p",
+        "command": "showPrevParameterHint",
+        "when": "editorTextFocus && parameterHintsVisible"
+      },
+      {
+        "key": "ctrl+n",
+        "command": "showNextParameterHint",
+        "when": "editorTextFocus && parameterHintsVisible"
+      },
+      {
+        "key": "ctrl+p",
+        "command": "selectPrevQuickFix",
+        "when": "editorFocus && quickFixWidgetVisible"
+      },
+      {
+        "key": "ctrl+n",
+        "command": "selectNextQuickFix",
+        "when": "editorFocus && quickFixWidgetVisible"
+      },
+      {
+        "key": "ctrl+p",
+        "command": "selectPrevSuggestion",
+        "when": "editorTextFocus && suggestWidgetVisible"
+      },
+      {
+        "key": "ctrl+n",
+        "command": "selectNextSuggestion",
+        "when": "editorTextFocus && suggestWidgetVisible"
+      },
+      {
+        "key": "ctrl+p",
+        "command": "workbench.action.quickOpenNavigatePrevious",
+        "when": "inQuickOpen"
+      },
+      {
+        "key": "ctrl+n",
+        "command": "workbench.action.quickOpenNavigateNext",
+        "when": "inQuickOpen"
+      },
+      {
+        "key": "ctrl+'",
+        "command": "editor.action.triggerSuggest",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+'",
+        "command": "toggleSuggestionDetails",
+        "when": "editorTextFocus && suggestWidgetVisible"
+      },
+      {
+        "key": "ctrl+shift+'",
+        "command": "editor.action.triggerParameterHints",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "alt+x",
+        "command": "workbench.action.showCommands"
+      },
+      {
+        "key": "ctrl+alt+space",
+        "command": "workbench.action.toggleSidebarVisibility"
+      },
+      {
+        "key": "ctrl+x b",
+        "command": "workbench.action.showAllEditors"
+      },
+      {
+        "key": "ctrl+shift+backspace",
+        "command": "emacs.C-S_bs",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+x ctrl+l",
+        "command": "editor.action.transformToLowercase",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "ctrl+x ctrl+u",
+        "command": "editor.action.transformToUppercase",
+        "when": "editorTextFocus && !editorReadonly"
+      },
+      {
+        "key": "alt+backspace",
+        "command": "deleteWordLeft",
+        "when": "editorTextFocus && !editorReadonly"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "tsc -p ./",
+    "compile": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "lint": "tslint -p tslint.json --type-check **/*.ts"
+  },
+  "devDependencies": {
+    "@types/mocha": "^2.2.41",
+    "@types/node": "^6.0.81",
+    "mocha": "^3.4.2",
+    "typescript": "^2.4.1",
+    "vscode": "^1.1.4"
+  },
+  "dependencies": {
+    "clipboardy": "^1.1.4"
+  }
 }


### PR DESCRIPTION
Hello,
I appreciate your plugin a lot as I have the emacs keybindings burnt into my brain but would like to be able to use vscode sometimes, especially on windows and with typescript.

I often finding myself hitting ctrl-o with the intent of opening a new line but instead getting a file dialog. This simple pull request binds ctrl-o to editor.action.insertLineBefore which seems to do what I expect from my long use of emacs. It is a small change but useful for me.