### PR TITLE
MarkMode with multi cursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -395,7 +395,7 @@
             {
                 "key": "ctrl+g",
                 "command": "emacs.exitMarkMode",
-                "when": "editorTextFocus && editorHasSelection"
+                "when": "editorTextFocus"
             },
             {
                 "key": "ctrl+g",
@@ -406,11 +406,6 @@
                 "key": "ctrl+g",
                 "command": "closeReferenceSearch",
                 "when": "referenceSearchVisible && !config.editor.stablePeek"
-            },
-            {
-                "key": "ctrl+g",
-                "command": "removeSecondaryCursors",
-                "when": "editorHasMultipleSelections && editorTextFocus"
             },
             {
                 "key": "ctrl+g",


### PR DESCRIPTION
Thank you for the great work on this useful extension.

The current version does not handle multi-cursor with mark-mode
because it initializes only `TextEditor.selection` (=`TextEditor.selections[0]`) in `initSelection()` as following:
https://github.com/SebastianZaha/vscode-emacs-friendly/blob/d40f78b965f5145af6f0c2a356409cb630f445a4/src/extension.ts#L78-L81

That's why mark-mode does not work with multi cursor as following:
![multi-cursor-mark-demo-prev-ver](https://user-images.githubusercontent.com/3135397/50584900-96992880-0eb5-11e9-9bc1-9e3f4b43c1b7.gif)
(When mark-mode starts, multi cursor mode is canceled and only one cursor remains)

In this PR, that behavior is modified to initialize all selections.
This makes mark-mode of this extension work with multi-cursor as following:
![multi-cursor-mark](https://user-images.githubusercontent.com/3135397/50584748-d01d6400-0eb4-11e9-9e4b-5b830b26f02c.gif)

In addition to that, I modified the behavior of `ctrl-g` along with multi cursor
so that
* When multi cursor is enabled and one ore more non-empty selections exist, `ctrl-g` cancels the selections
* When multi cursor is enabled and no non-empty selections exist, `ctrl-g` cancels multi cursor mode
* When multi cursor is not enabled (only single cursor exists), `ctrl-g` cancels the selection whether or not it is empty. This is just same as the original behavior (`cancelSelection` command).

I love this modified behavior, but I know that this should be considered before it is merged to the master branch.

Thank you.