### PR TITLE
Window splitting keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ The following are some of the changes and enhancements from the original:
 | `C-x k` | Close current tab (buffer) |
 | `C-x C-k` | Close all tabs |
 | `C-x 1` | Close editors in other (split) group.  |
-| `C-x 2` | Split editor |
-| `C-x 3` | Toggle split layout (vertical to horizontal) |
+| `C-x 2` | Split editor horizontal |
+| `C-x 3` | Split editor vertical |
+| `C-x 4` | Toggle split layout (vertical to horizontal) |
 | `C-x o` | Focus other split editor |
 
 ## Conflicts with default key bindings

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The following are some of the changes and enhancements from the original:
 | `C-x C-f` | QuickOpen a file |
 | `C-x k` | Close current tab (buffer) |
 | `C-x C-k` | Close all tabs |
+| `C-x 0` | Close editors in the current group.  |
 | `C-x 1` | Close editors in other (split) group.  |
 | `C-x 2` | Split editor horizontal |
 | `C-x 3` | Split editor vertical |

--- a/package.json
+++ b/package.json
@@ -499,6 +499,10 @@
                 "command": "workbench.action.newWindow"
             },
             {
+                "key": "ctrl+x 0",
+                "command": "workbench.action.closeEditorsInGroup"
+            },
+            {
                 "key": "ctrl+x 1",
                 "command": "workbench.action.closeEditorsInOtherGroups"
             },

--- a/package.json
+++ b/package.json
@@ -504,10 +504,14 @@
             },
             {
                 "key": "ctrl+x 2",
-                "command": "workbench.action.splitEditor"
+                "command": "workbench.action.splitEditorDown"
             },
             {
                 "key": "ctrl+x 3",
+                "command": "workbench.action.splitEditorRight"
+            },
+            {
+                "key": "ctrl+x 4",
                 "command": "workbench.action.toggleEditorGroupLayout"
             },
             {


### PR DESCRIPTION
Based on #58, `ctrl-x 0` was added.
Thank you, @brother