### PR TITLE
work with remote development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.3 (2019-06-06)
+- FIX work with remove development
+
 ## 0.8.2 (2017-10-09)
 - Fix replaceOne shortcut to correctly only replace the currently selected match
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Emacs Friendly Keymap",
     "description": "Emacs keybindings and selection, friendly interaction with the system clipboard.",
     "icon": "emacs_pacifica.png",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "publisher": "lfs",
     "homepage": "https://github.com/SebastianZaha/vscode-emacs-friendly",
     "repository": {
@@ -12,7 +12,7 @@
     },
     "bugs": "https://github.com/SebastianZaha/vscode-emacs-friendly/issues",
     "engines": {
-        "vscode": "^1.11.0"
+        "vscode": "^1.30.0"
     },
     "categories": [
         "Other",
@@ -616,7 +616,5 @@
         "typescript": "^2.4.1",
         "vscode": "^1.1.4"
     },
-    "dependencies": {
-        "clipboardy": "^1.1.4"
-    }
+    "dependencies": {}
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import * as clip from 'clipboardy'
 
 // Possible positions when C-l is invoked consequtively
 enum RecenterPosition {
@@ -107,15 +106,15 @@ export class Editor {
 	}
 
 	copy(): void {
-		clip.writeSync(this.getSelectionText())
+		vscode.env.clipboard.writeText(this.getSelectionText())
 		vscode.commands.executeCommand("emacs.exitMarkMode")
 	}
 
 	cut(appendClipboard?: boolean): Thenable<boolean> {
 		if (appendClipboard) {
-			clip.writeSync(clip.readSync() + this.getSelectionText());
+			vscode.env.clipboard.writeText(vscode.env.clipboard.readText() + this.getSelectionText())
 		} else {
-			clip.writeSync(this.getSelectionText());
+			vscode.env.clipboard.writeText(this.getSelectionText())
 		}
 		let t = Editor.delete(this.getSelectionRange());
 		vscode.commands.executeCommand("emacs.exitMarkMode");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
         "target": "es6",
         "outDir": "out",
         "lib": [
-            "es6"
+            "es6",
+            "esnext.asynciterable"
         ],
         "sourceMap": true,
         "rootDir": ".",


### PR DESCRIPTION
I've started to use vscode with remote development extensions.
when connect to ubuntu from windows/mac,
I can not cut / copy text
I've fixed.

official site says that this is because of using clipboardby library.
https://code.visualstudio.com/docs/remote/troubleshooting#_clipboard-does-not-work
https://code.visualstudio.com/api/advanced-topics/remote-extensions#using-the-clipboard

please check it.