### PR TITLE
Make it possible that yank overwrites selection correctly

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -122,11 +122,10 @@ export class Editor {
 		return t
 	}
 
-	yank(): Thenable<{}> {
+	async yank(): Promise<boolean> {
 		this.justDidKill = false
-		return Promise.all([
-			vscode.commands.executeCommand("editor.action.clipboardPasteAction"),
-			vscode.commands.executeCommand("emacs.exitMarkMode")])
+		await vscode.commands.executeCommand("editor.action.clipboardPasteAction");
+		return vscode.commands.executeCommand("emacs.exitMarkMode")
 	}
 
 	undo(): void {


### PR DESCRIPTION
README.md says that yank overwrites selection, but this feature doesn't work correctly.  Maybe this is because `editor.action.clipboardPasteAction` and `emacs.exitMarkMode` are running in parallel using Promise.all.

In this pull request, I fixed yank to replace selection collectly.